### PR TITLE
Udate example branch name to be consitent with codecommit

### DIFF
--- a/config/env.yaml
+++ b/config/env.yaml
@@ -13,7 +13,7 @@ PipelineSettings:
   SSOServiceAccountId: "<ORGMAIN Account ID>"
   SSOServiceAccountRegion: "<ORGMAIN Account region>"
   RepoArn: "arn:aws:codecommit:<DEPLOY Account Region>:<DEPLOY Account ID>:aws-sso-extensions-for-enterprise"
-  RepoBranchName: "main"
+  RepoBranchName: "master"
   SynthCommand: "yarn cdk synth env-aws-sso-extensions-for-enterprise -c config=env --quiet"
 
 Parameters:


### PR DESCRIPTION

*Description of changes:*
Update example env file to be aligned with the default branch name that is given when creating a codecommit repository, which is "master" instead of "main"

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
