### PR TITLE
Refactor cross stack references

### DIFF
--- a/config/env.yaml
+++ b/config/env.yaml
@@ -1,7 +1,7 @@
 ---
 App: "aws-sso-extensions-for-enterprise"
 Environment: "env"
-Version: "1.1.0"
+Version: "2.0.0"
 
 PipelineSettings:
   BootstrapQualifier: "<your-bootstrap-qualifier>" # For example: 'ssoutility'

--- a/lib/constructs/access-manager.ts
+++ b/lib/constructs/access-manager.ts
@@ -1,29 +1,20 @@
 /*
-Since, there are more than 100+ resources
-being created in the solutions artefact stack, 
-all access granting within the stack is consolidated
+All access granting within the solution artefacts stack is consolidated
 here to facilitate easier management and visibility
 */
 
 import { PolicyStatement } from "aws-cdk-lib/aws-iam";
 import { Construct } from "constructs";
-import { BuildConfig } from "../build/buildConfig";
-import { IndependentUtility } from "./independent-utlity";
-import { LinkCRUD } from "./link-crud";
+import { FetchCrossStackValues } from "./fetch-cross-stack-values";
 import { LinkProcessor } from "./link-processor";
 import { OrgEvents } from "./org-events";
-import { PermissionSetCRUD } from "./permission-set-crud";
 import { PermissionSetProcessor } from "./permission-set-processor";
 import { SSOGroupCRUD } from "./sso-group-crud";
 import { SSOGroupProcessor } from "./sso-group-processor";
-import { Utility } from "./utility";
 
 export interface AccessManagerProps {
-  readonly IndependentUtility: IndependentUtility;
-  readonly LinkCRUD: LinkCRUD;
-  readonly PermissionSetCRUD: PermissionSetCRUD;
+  readonly FetchCrossStackValues: FetchCrossStackValues;
   readonly SSOGroupCRUD: SSOGroupCRUD;
-  readonly Utility: Utility;
   readonly LinkProcessor: LinkProcessor;
   readonly PermissionSetProcessor: PermissionSetProcessor;
   readonly SSOGroupProcessor: SSOGroupProcessor;
@@ -34,389 +25,238 @@ export class AccessManager extends Construct {
   constructor(
     scope: Construct,
     id: string,
-    buildConfig: BuildConfig,
     accessManagerProps: AccessManagerProps
   ) {
     super(scope, id);
 
-    accessManagerProps.IndependentUtility.errorNotificationsTopic.grantPublish(
-      accessManagerProps.Utility.waiterHandler
-    );
-
-    accessManagerProps.IndependentUtility.snsTopicsKey.grantEncryptDecrypt(
-      accessManagerProps.Utility.waiterHandler
-    );
-
-    if (buildConfig.Parameters.LinksProvisioningMode.toLowerCase() === "api") {
-      accessManagerProps.LinkCRUD.linksTable.grantReadWriteData(
-        accessManagerProps.LinkCRUD.linkAPIHandler
-      );
-
-      accessManagerProps.IndependentUtility.ssoArtefactsBucket.grantReadWrite(
-        accessManagerProps.LinkCRUD.linkAPIHandler
-      );
-
-      accessManagerProps.IndependentUtility.s3ArtefactsKey.grantEncryptDecrypt(
-        accessManagerProps.LinkCRUD.linkAPIHandler
-      );
-    } else {
-      accessManagerProps.LinkCRUD.linksTable.grantReadWriteData(
-        accessManagerProps.LinkCRUD.linkCuHandler
-      );
-      accessManagerProps.LinkCRUD.linksTable.grantReadWriteData(
-        accessManagerProps.LinkCRUD.linkDelHandler
-      );
-      accessManagerProps.IndependentUtility.ssoArtefactsBucket.grantRead(
-        accessManagerProps.LinkCRUD.linkCuHandler
-      );
-      accessManagerProps.IndependentUtility.s3ArtefactsKey.grantEncryptDecrypt(
-        accessManagerProps.LinkCRUD.linkCuHandler
-      );
-      accessManagerProps.IndependentUtility.ssoArtefactsBucket.grantRead(
-        accessManagerProps.LinkCRUD.linkDelHandler
-      );
-      accessManagerProps.IndependentUtility.s3ArtefactsKey.grantEncryptDecrypt(
-        accessManagerProps.LinkCRUD.linkDelHandler
-      );
-      accessManagerProps.IndependentUtility.errorNotificationsTopic.grantPublish(
-        accessManagerProps.LinkCRUD.linkCuHandler
-      );
-      accessManagerProps.IndependentUtility.snsTopicsKey.grantEncryptDecrypt(
-        accessManagerProps.LinkCRUD.linkCuHandler
-      );
-      accessManagerProps.IndependentUtility.errorNotificationsTopic.grantPublish(
-        accessManagerProps.LinkCRUD.linkDelHandler
-      );
-      accessManagerProps.IndependentUtility.snsTopicsKey.grantEncryptDecrypt(
-        accessManagerProps.LinkCRUD.linkDelHandler
-      );
-    }
-
-    if (
-      buildConfig.Parameters.PermissionSetProvisioningMode.toLowerCase() ===
-      "api"
-    ) {
-      accessManagerProps.LinkCRUD.linksTable.grantReadData(
-        accessManagerProps.PermissionSetCRUD.permissionSetAPIHandler
-      );
-      accessManagerProps.PermissionSetCRUD.permissionSetTable.grantReadWriteData(
-        accessManagerProps.PermissionSetCRUD.permissionSetAPIHandler
-      );
-
-      accessManagerProps.IndependentUtility.ssoArtefactsBucket.grantReadWrite(
-        accessManagerProps.PermissionSetCRUD.permissionSetAPIHandler
-      );
-      accessManagerProps.IndependentUtility.s3ArtefactsKey.grantEncryptDecrypt(
-        accessManagerProps.PermissionSetCRUD.permissionSetAPIHandler
-      );
-    } else {
-      accessManagerProps.IndependentUtility.errorNotificationsTopic.grantPublish(
-        accessManagerProps.PermissionSetCRUD.permissionSetCuHandler
-      );
-      accessManagerProps.IndependentUtility.snsTopicsKey.grantEncryptDecrypt(
-        accessManagerProps.PermissionSetCRUD.permissionSetCuHandler
-      );
-      accessManagerProps.IndependentUtility.errorNotificationsTopic.grantPublish(
-        accessManagerProps.PermissionSetCRUD.permissionSetDelHandler
-      );
-      accessManagerProps.IndependentUtility.snsTopicsKey.grantEncryptDecrypt(
-        accessManagerProps.PermissionSetCRUD.permissionSetDelHandler
-      );
-      accessManagerProps.LinkCRUD.linksTable.grantReadData(
-        accessManagerProps.PermissionSetCRUD.permissionSetDelHandler
-      );
-      accessManagerProps.PermissionSetCRUD.permissionSetTable.grantReadWriteData(
-        accessManagerProps.PermissionSetCRUD.permissionSetCuHandler
-      );
-      accessManagerProps.PermissionSetCRUD.permissionSetTable.grantReadWriteData(
-        accessManagerProps.PermissionSetCRUD.permissionSetDelHandler
-      );
-      accessManagerProps.IndependentUtility.ssoArtefactsBucket.grantRead(
-        accessManagerProps.PermissionSetCRUD.permissionSetCuHandler
-      );
-      accessManagerProps.IndependentUtility.s3ArtefactsKey.grantDecrypt(
-        accessManagerProps.PermissionSetCRUD.permissionSetCuHandler
-      );
-
-      accessManagerProps.IndependentUtility.ssoArtefactsBucket.grantRead(
-        accessManagerProps.PermissionSetCRUD.permissionSetDelHandler
-      );
-      accessManagerProps.IndependentUtility.s3ArtefactsKey.grantDecrypt(
-        accessManagerProps.PermissionSetCRUD.permissionSetDelHandler
-      );
-    }
-
-    accessManagerProps.IndependentUtility.errorNotificationsTopic.grantPublish(
+    // Link Manager Handler access
+    accessManagerProps.FetchCrossStackValues.snsTopicsKey.grantEncryptDecrypt(
       accessManagerProps.LinkProcessor.linkManagerHandler
     );
-
-    accessManagerProps.IndependentUtility.snsTopicsKey.grantEncryptDecrypt(
+    accessManagerProps.FetchCrossStackValues.errorNotificationsTopic.grantPublish(
       accessManagerProps.LinkProcessor.linkManagerHandler
     );
-
-    accessManagerProps.IndependentUtility.errorNotificationsTopic.grantPublish(
-      accessManagerProps.PermissionSetProcessor.permissionSetHandler
-    );
-
-    accessManagerProps.IndependentUtility.snsTopicsKey.grantEncryptDecrypt(
-      accessManagerProps.PermissionSetProcessor.permissionSetHandler
-    );
-
-    accessManagerProps.IndependentUtility.errorNotificationsTopic.grantPublish(
-      accessManagerProps.PermissionSetProcessor.permissionSetStreamHandler
-    );
-
-    accessManagerProps.IndependentUtility.snsTopicsKey.grantEncryptDecrypt(
-      accessManagerProps.PermissionSetProcessor.permissionSetStreamHandler
-    );
-
-    accessManagerProps.IndependentUtility.errorNotificationsTopic.grantPublish(
-      accessManagerProps.SSOGroupProcessor.ssoGroupHandler
-    );
-
-    accessManagerProps.IndependentUtility.snsTopicsKey.grantEncryptDecrypt(
-      accessManagerProps.SSOGroupProcessor.ssoGroupHandler
-    );
-
-    accessManagerProps.IndependentUtility.errorNotificationsTopic.grantPublish(
-      accessManagerProps.LinkProcessor.linkStreamHandler
-    );
-
-    accessManagerProps.IndependentUtility.snsTopicsKey.grantEncryptDecrypt(
-      accessManagerProps.LinkProcessor.linkStreamHandler
-    );
-
-    accessManagerProps.IndependentUtility.errorNotificationsTopic.grantPublish(
-      accessManagerProps.OrgEvents.orgEventsHandler
-    );
-
-    accessManagerProps.IndependentUtility.snsTopicsKey.grantEncryptDecrypt(
-      accessManagerProps.OrgEvents.orgEventsHandler
-    );
-
-    accessManagerProps.IndependentUtility.errorNotificationsTopic.grantPublish(
-      accessManagerProps.PermissionSetProcessor.permissionSetSyncHandler
-    );
-
-    accessManagerProps.IndependentUtility.snsTopicsKey.grantEncryptDecrypt(
-      accessManagerProps.PermissionSetProcessor.permissionSetSyncHandler
-    );
-
-    accessManagerProps.PermissionSetCRUD.permissionSetTable.grantStreamRead(
-      accessManagerProps.PermissionSetProcessor.permissionSetStreamHandler
-    );
-    accessManagerProps.LinkCRUD.linksTable.grantStreamRead(
-      accessManagerProps.LinkProcessor.linkStreamHandler
-    );
-    accessManagerProps.PermissionSetProcessor.permissionSetTopic.grantPublish(
-      accessManagerProps.PermissionSetProcessor.permissionSetStreamHandler
-    );
-
-    accessManagerProps.IndependentUtility.snsTopicsKey.grantEncryptDecrypt(
-      accessManagerProps.PermissionSetProcessor.permissionSetStreamHandler
-    );
-
-    accessManagerProps.PermissionSetProcessor.permissionSetSyncTopic.grantPublish(
-      accessManagerProps.PermissionSetProcessor.permissionSetHandler
-    );
-
-    accessManagerProps.IndependentUtility.snsTopicsKey.grantEncryptDecrypt(
-      accessManagerProps.PermissionSetProcessor.permissionSetHandler
-    );
-
-    accessManagerProps.LinkProcessor.linkManagerTopic.grantPublish(
-      accessManagerProps.LinkProcessor.linkStreamHandler
-    );
-
-    accessManagerProps.IndependentUtility.snsTopicsKey.grantEncryptDecrypt(
-      accessManagerProps.LinkProcessor.linkStreamHandler
-    );
-
-    accessManagerProps.PermissionSetCRUD.permissionSetTable.grantReadWriteData(
-      accessManagerProps.PermissionSetProcessor.permissionSetHandler
-    );
-    accessManagerProps.PermissionSetCRUD.permissionSetArnTable.grantReadWriteData(
-      accessManagerProps.PermissionSetProcessor.permissionSetHandler
-    );
-
-    accessManagerProps.SSOGroupCRUD.groupsTable.grantReadWriteData(
-      accessManagerProps.SSOGroupProcessor.ssoGroupHandler
-    );
-
-    accessManagerProps.SSOGroupCRUD.groupsTable.grantReadData(
-      accessManagerProps.PermissionSetProcessor.permissionSetHandler
-    );
-
-    accessManagerProps.SSOGroupCRUD.groupsTable.grantReadWriteData(
-      accessManagerProps.OrgEvents.orgEventsHandler
-    );
-    accessManagerProps.SSOGroupCRUD.groupsTable.grantReadWriteData(
-      accessManagerProps.PermissionSetProcessor.permissionSetSyncHandler
-    );
-    accessManagerProps.LinkCRUD.linksTable.grantReadWriteData(
-      accessManagerProps.SSOGroupProcessor.ssoGroupHandler
-    );
-
-    accessManagerProps.LinkCRUD.linksTable.grantReadData(
-      accessManagerProps.PermissionSetProcessor.permissionSetSyncHandler
-    );
-
-    accessManagerProps.LinkProcessor.linkManagerTopic.grantPublish(
-      accessManagerProps.SSOGroupProcessor.ssoGroupHandler
-    );
-    accessManagerProps.IndependentUtility.snsTopicsKey.grantEncryptDecrypt(
-      accessManagerProps.SSOGroupProcessor.ssoGroupHandler
-    );
-    accessManagerProps.LinkProcessor.linkManagerTopic.grantPublish(
-      accessManagerProps.OrgEvents.orgEventsHandler
-    );
-    accessManagerProps.IndependentUtility.snsTopicsKey.grantEncryptDecrypt(
-      accessManagerProps.OrgEvents.orgEventsHandler
-    );
-    accessManagerProps.LinkProcessor.linkManagerTopic.grantPublish(
-      accessManagerProps.PermissionSetProcessor.permissionSetSyncHandler
-    );
-    accessManagerProps.IndependentUtility.snsTopicsKey.grantEncryptDecrypt(
-      accessManagerProps.PermissionSetProcessor.permissionSetSyncHandler
-    );
-
-    accessManagerProps.LinkProcessor.linkManagerTopic.grantPublish(
-      accessManagerProps.LinkProcessor.processTargetAccountSMListenerHandler
-    );
-
-    accessManagerProps.IndependentUtility.snsTopicsKey.grantEncryptDecrypt(
-      accessManagerProps.LinkProcessor.processTargetAccountSMListenerHandler
-    );
-
-    accessManagerProps.LinkCRUD.linksTable.grantReadData(
-      accessManagerProps.LinkProcessor.linkStreamHandler
-    );
-    accessManagerProps.SSOGroupCRUD.groupsTable.grantReadWriteData(
-      accessManagerProps.LinkProcessor.linkStreamHandler
-    );
-    accessManagerProps.LinkCRUD.linksTable.grantReadWriteData(
-      accessManagerProps.SSOGroupProcessor.ssoGroupHandler
-    );
-
-    accessManagerProps.LinkCRUD.linksTable.grantReadData(
-      accessManagerProps.OrgEvents.orgEventsHandler
-    );
-
-    accessManagerProps.PermissionSetCRUD.permissionSetArnTable.grantReadData(
-      accessManagerProps.SSOGroupProcessor.ssoGroupHandler
-    );
-    accessManagerProps.PermissionSetCRUD.permissionSetArnTable.grantReadData(
-      accessManagerProps.LinkProcessor.linkStreamHandler
-    );
-    accessManagerProps.PermissionSetCRUD.permissionSetArnTable.grantReadData(
-      accessManagerProps.OrgEvents.orgEventsHandler
-    );
-
-    accessManagerProps.LinkCRUD.provisionedLinksTable.grantReadData(
+    accessManagerProps.FetchCrossStackValues.waiterHandlerNotificationsTopic.grantPublish(
       accessManagerProps.LinkProcessor.linkManagerHandler
     );
-    accessManagerProps.LinkCRUD.provisionedLinksTable.grantReadWriteData(
-      accessManagerProps.Utility.waiterHandler
-    );
-
-    accessManagerProps.Utility.waiterHandlerNotificationsTopic.grantPublish(
-      accessManagerProps.PermissionSetProcessor.permissionSetHandler
-    );
-
-    accessManagerProps.IndependentUtility.snsTopicsKey.grantEncryptDecrypt(
-      accessManagerProps.PermissionSetProcessor.permissionSetHandler
-    );
-
-    accessManagerProps.Utility.waiterHandlerNotificationsTopic.grantPublish(
+    accessManagerProps.FetchCrossStackValues.ddbTablesKey.grantEncryptDecrypt(
       accessManagerProps.LinkProcessor.linkManagerHandler
     );
-    accessManagerProps.IndependentUtility.snsTopicsKey.grantEncryptDecrypt(
+    accessManagerProps.FetchCrossStackValues.provisionedLinksTable.grantReadData(
       accessManagerProps.LinkProcessor.linkManagerHandler
     );
-
-    accessManagerProps.IndependentUtility.ddbTablesKey.grantEncryptDecrypt(
-      accessManagerProps.LinkProcessor.linkStreamHandler
-    );
-
-    accessManagerProps.IndependentUtility.ddbTablesKey.grantEncryptDecrypt(
-      accessManagerProps.PermissionSetProcessor.permissionSetStreamHandler
-    );
-
-    accessManagerProps.LinkCRUD.provisionedLinksTable.grantReadData(
-      accessManagerProps.OrgEvents.orgEventsHandler
-    );
-
     accessManagerProps.LinkProcessor.linkManagerHandler.addToRolePolicy(
       new PolicyStatement({
         resources: [
-          accessManagerProps.IndependentUtility.linkManagerHandlerSSOAPIRoleArn,
+          accessManagerProps.FetchCrossStackValues
+            .linkManagerHandlerSSOAPIRoleArn,
         ],
         actions: ["sts:AssumeRole"],
       })
     );
 
-    accessManagerProps.LinkProcessor.linkStreamHandler.addToRolePolicy(
-      new PolicyStatement({
-        resources: [
-          accessManagerProps.IndependentUtility.listInstancesSSOAPIRoleArn,
-          accessManagerProps.IndependentUtility
-            .listGroupsIdentityStoreAPIRoleArn,
-          accessManagerProps.IndependentUtility
-            .processTargetAccountSMInvokeRoleArn,
-        ],
-        actions: ["sts:AssumeRole"],
-      })
+    // Permission Set Topic Handler access
+    accessManagerProps.FetchCrossStackValues.snsTopicsKey.grantEncryptDecrypt(
+      accessManagerProps.PermissionSetProcessor.permissionSetHandler
     );
-
-    accessManagerProps.OrgEvents.orgEventsHandler.addToRolePolicy(
-      new PolicyStatement({
-        resources: [
-          accessManagerProps.IndependentUtility.listInstancesSSOAPIRoleArn,
-          accessManagerProps.IndependentUtility
-            .listGroupsIdentityStoreAPIRoleArn,
-        ],
-        actions: ["sts:AssumeRole"],
-      })
+    accessManagerProps.FetchCrossStackValues.errorNotificationsTopic.grantPublish(
+      accessManagerProps.PermissionSetProcessor.permissionSetHandler
     );
-
+    accessManagerProps.PermissionSetProcessor.permissionSetSyncTopic.grantPublish(
+      accessManagerProps.PermissionSetProcessor.permissionSetHandler
+    );
+    accessManagerProps.FetchCrossStackValues.waiterHandlerNotificationsTopic.grantPublish(
+      accessManagerProps.PermissionSetProcessor.permissionSetHandler
+    );
+    accessManagerProps.FetchCrossStackValues.ddbTablesKey.grantEncryptDecrypt(
+      accessManagerProps.PermissionSetProcessor.permissionSetHandler
+    );
+    accessManagerProps.FetchCrossStackValues.permissionSetTable.grantReadWriteData(
+      accessManagerProps.PermissionSetProcessor.permissionSetHandler
+    );
+    accessManagerProps.FetchCrossStackValues.permissionSetArnTable.grantReadWriteData(
+      accessManagerProps.PermissionSetProcessor.permissionSetHandler
+    );
+    accessManagerProps.SSOGroupCRUD.groupsTable.grantReadData(
+      accessManagerProps.PermissionSetProcessor.permissionSetHandler
+    );
     accessManagerProps.PermissionSetProcessor.permissionSetHandler.addToRolePolicy(
       new PolicyStatement({
         resources: [
-          accessManagerProps.IndependentUtility
+          accessManagerProps.FetchCrossStackValues
             .permissionSetHandlerSSOAPIRoleArn,
         ],
         actions: ["sts:AssumeRole"],
       })
     );
 
+    // Permission Set Stream Handler access
+    accessManagerProps.FetchCrossStackValues.snsTopicsKey.grantEncryptDecrypt(
+      accessManagerProps.PermissionSetProcessor.permissionSetStreamHandler
+    );
+    accessManagerProps.FetchCrossStackValues.errorNotificationsTopic.grantPublish(
+      accessManagerProps.PermissionSetProcessor.permissionSetStreamHandler
+    );
+    accessManagerProps.PermissionSetProcessor.permissionSetTopic.grantPublish(
+      accessManagerProps.PermissionSetProcessor.permissionSetStreamHandler
+    );
+    accessManagerProps.FetchCrossStackValues.ddbTablesKey.grantEncryptDecrypt(
+      accessManagerProps.PermissionSetProcessor.permissionSetStreamHandler
+    );
+    accessManagerProps.FetchCrossStackValues.permissionSetTable.grantStreamRead(
+      accessManagerProps.PermissionSetProcessor.permissionSetStreamHandler
+    );
+
+    // SSO Group Handler access
+    accessManagerProps.FetchCrossStackValues.snsTopicsKey.grantEncryptDecrypt(
+      accessManagerProps.SSOGroupProcessor.ssoGroupHandler
+    );
+    accessManagerProps.FetchCrossStackValues.errorNotificationsTopic.grantPublish(
+      accessManagerProps.SSOGroupProcessor.ssoGroupHandler
+    );
+    accessManagerProps.LinkProcessor.linkManagerTopic.grantPublish(
+      accessManagerProps.SSOGroupProcessor.ssoGroupHandler
+    );
+    accessManagerProps.FetchCrossStackValues.ddbTablesKey.grantEncryptDecrypt(
+      accessManagerProps.SSOGroupProcessor.ssoGroupHandler
+    );
+    accessManagerProps.SSOGroupCRUD.groupsTable.grantReadWriteData(
+      accessManagerProps.SSOGroupProcessor.ssoGroupHandler
+    );
+    accessManagerProps.FetchCrossStackValues.linksTable.grantReadWriteData(
+      accessManagerProps.SSOGroupProcessor.ssoGroupHandler
+    );
+    accessManagerProps.FetchCrossStackValues.permissionSetArnTable.grantReadData(
+      accessManagerProps.SSOGroupProcessor.ssoGroupHandler
+    );
     accessManagerProps.SSOGroupProcessor.ssoGroupHandler.addToRolePolicy(
       new PolicyStatement({
         resources: [
-          accessManagerProps.IndependentUtility
+          accessManagerProps.FetchCrossStackValues
             .processTargetAccountSMInvokeRoleArn,
-          accessManagerProps.IndependentUtility.listInstancesSSOAPIRoleArn,
+          accessManagerProps.FetchCrossStackValues.listInstancesSSOAPIRoleArn,
         ],
         actions: ["sts:AssumeRole"],
       })
     );
 
-    accessManagerProps.Utility.waiterHandler.addToRolePolicy(
+    // Link Stream Handler access
+    accessManagerProps.FetchCrossStackValues.snsTopicsKey.grantEncryptDecrypt(
+      accessManagerProps.LinkProcessor.linkStreamHandler
+    );
+    accessManagerProps.FetchCrossStackValues.errorNotificationsTopic.grantPublish(
+      accessManagerProps.LinkProcessor.linkStreamHandler
+    );
+    accessManagerProps.LinkProcessor.linkManagerTopic.grantPublish(
+      accessManagerProps.LinkProcessor.linkStreamHandler
+    );
+    accessManagerProps.FetchCrossStackValues.ddbTablesKey.grantEncryptDecrypt(
+      accessManagerProps.LinkProcessor.linkStreamHandler
+    );
+    accessManagerProps.FetchCrossStackValues.linksTable.grantStreamRead(
+      accessManagerProps.LinkProcessor.linkStreamHandler
+    );
+    accessManagerProps.FetchCrossStackValues.linksTable.grantReadData(
+      accessManagerProps.LinkProcessor.linkStreamHandler
+    );
+    accessManagerProps.SSOGroupCRUD.groupsTable.grantReadWriteData(
+      accessManagerProps.LinkProcessor.linkStreamHandler
+    );
+    accessManagerProps.FetchCrossStackValues.permissionSetArnTable.grantReadData(
+      accessManagerProps.LinkProcessor.linkStreamHandler
+    );
+    accessManagerProps.LinkProcessor.linkStreamHandler.addToRolePolicy(
       new PolicyStatement({
         resources: [
-          accessManagerProps.IndependentUtility.waiterHandlerSSOAPIRoleArn,
+          accessManagerProps.FetchCrossStackValues.listInstancesSSOAPIRoleArn,
+          accessManagerProps.FetchCrossStackValues
+            .listGroupsIdentityStoreAPIRoleArn,
+          accessManagerProps.FetchCrossStackValues
+            .processTargetAccountSMInvokeRoleArn,
         ],
         actions: ["sts:AssumeRole"],
       })
     );
 
+    // Org Events Handler Access
+    accessManagerProps.FetchCrossStackValues.snsTopicsKey.grantEncryptDecrypt(
+      accessManagerProps.OrgEvents.orgEventsHandler
+    );
+    accessManagerProps.FetchCrossStackValues.errorNotificationsTopic.grantPublish(
+      accessManagerProps.OrgEvents.orgEventsHandler
+    );
+    accessManagerProps.LinkProcessor.linkManagerTopic.grantPublish(
+      accessManagerProps.OrgEvents.orgEventsHandler
+    );
+    accessManagerProps.FetchCrossStackValues.ddbTablesKey.grantEncryptDecrypt(
+      accessManagerProps.OrgEvents.orgEventsHandler
+    );
+    accessManagerProps.SSOGroupCRUD.groupsTable.grantReadWriteData(
+      accessManagerProps.OrgEvents.orgEventsHandler
+    );
+    accessManagerProps.FetchCrossStackValues.linksTable.grantReadData(
+      accessManagerProps.OrgEvents.orgEventsHandler
+    );
+    accessManagerProps.FetchCrossStackValues.permissionSetArnTable.grantReadData(
+      accessManagerProps.OrgEvents.orgEventsHandler
+    );
+    accessManagerProps.FetchCrossStackValues.provisionedLinksTable.grantReadData(
+      accessManagerProps.OrgEvents.orgEventsHandler
+    );
+    accessManagerProps.OrgEvents.orgEventsHandler.addToRolePolicy(
+      new PolicyStatement({
+        resources: [
+          accessManagerProps.FetchCrossStackValues.listInstancesSSOAPIRoleArn,
+          accessManagerProps.FetchCrossStackValues
+            .listGroupsIdentityStoreAPIRoleArn,
+        ],
+        actions: ["sts:AssumeRole"],
+      })
+    );
+
+    // Permission Set Sync Handler access
+    accessManagerProps.FetchCrossStackValues.snsTopicsKey.grantEncryptDecrypt(
+      accessManagerProps.PermissionSetProcessor.permissionSetSyncHandler
+    );
+    accessManagerProps.FetchCrossStackValues.errorNotificationsTopic.grantPublish(
+      accessManagerProps.PermissionSetProcessor.permissionSetSyncHandler
+    );
+    accessManagerProps.LinkProcessor.linkManagerTopic.grantPublish(
+      accessManagerProps.PermissionSetProcessor.permissionSetSyncHandler
+    );
+    accessManagerProps.FetchCrossStackValues.ddbTablesKey.grantEncryptDecrypt(
+      accessManagerProps.PermissionSetProcessor.permissionSetSyncHandler
+    );
+    accessManagerProps.SSOGroupCRUD.groupsTable.grantReadWriteData(
+      accessManagerProps.PermissionSetProcessor.permissionSetSyncHandler
+    );
+    accessManagerProps.FetchCrossStackValues.linksTable.grantReadData(
+      accessManagerProps.PermissionSetProcessor.permissionSetSyncHandler
+    );
     accessManagerProps.PermissionSetProcessor.permissionSetSyncHandler.addToRolePolicy(
       new PolicyStatement({
         resources: [
-          accessManagerProps.IndependentUtility.listInstancesSSOAPIRoleArn,
-          accessManagerProps.IndependentUtility
+          accessManagerProps.FetchCrossStackValues.listInstancesSSOAPIRoleArn,
+          accessManagerProps.FetchCrossStackValues
             .listGroupsIdentityStoreAPIRoleArn,
-          accessManagerProps.IndependentUtility
+          accessManagerProps.FetchCrossStackValues
             .processTargetAccountSMInvokeRoleArn,
+        ],
+        actions: ["sts:AssumeRole"],
+      })
+    );
+
+    //Process Target account SM Listener access
+    accessManagerProps.FetchCrossStackValues.snsTopicsKey.grantEncryptDecrypt(
+      accessManagerProps.LinkProcessor.processTargetAccountSMListenerHandler
+    );
+    accessManagerProps.LinkProcessor.linkManagerTopic.grantPublish(
+      accessManagerProps.LinkProcessor.processTargetAccountSMListenerHandler
+    );
+    accessManagerProps.FetchCrossStackValues.waiterHandler.addToRolePolicy(
+      new PolicyStatement({
+        resources: [
+          accessManagerProps.FetchCrossStackValues.waiterHandlerSSOAPIRoleArn,
         ],
         actions: ["sts:AssumeRole"],
       })

--- a/lib/constructs/fetch-cross-stack-values.ts
+++ b/lib/constructs/fetch-cross-stack-values.ts
@@ -1,0 +1,242 @@
+/*
+Construct to specifically read values from preSolutions
+Artefact stack. This is to avoid creating a circular 
+dependency through CFN exports and instead rely on SSM paramter
+store based reads
+*/
+
+import { ITable, Table } from "aws-cdk-lib/aws-dynamodb";
+import { IKey, Key } from "aws-cdk-lib/aws-kms";
+import * as lambda from "aws-cdk-lib/aws-lambda";
+import { ITopic, Topic } from "aws-cdk-lib/aws-sns";
+import { StringParameter } from "aws-cdk-lib/aws-ssm";
+import { Construct } from "constructs";
+import { BuildConfig } from "../build/buildConfig";
+import { SSMParamReader } from "./ssm-param-reader";
+
+function name(buildConfig: BuildConfig, resourcename: string): string {
+  return buildConfig.Environment + "-" + resourcename;
+}
+
+export class FetchCrossStackValues extends Construct {
+  public readonly errorNotificationsTopic: ITopic;
+  public readonly waiterHandlerNotificationsTopic: ITopic;
+  public readonly ssoGroupEventNotificationsTopic: ITopic;
+  public readonly orgEventsNotificationsTopic: ITopic;
+  public readonly processTargetAccountSMTopic: ITopic;
+  public readonly nodeJsLayer: lambda.ILayerVersion;
+  public readonly linksTable: ITable;
+  public readonly provisionedLinksTable: ITable;
+  public readonly permissionSetTable: ITable;
+  public readonly permissionSetArnTable: ITable;
+  public readonly snsTopicsKey: IKey;
+  public readonly ddbTablesKey: IKey;
+  public readonly permissionSetHandlerSSOAPIRoleArn: string;
+  public readonly linkManagerHandlerSSOAPIRoleArn: string;
+  public readonly listInstancesSSOAPIRoleArn: string;
+  public readonly listGroupsIdentityStoreAPIRoleArn: string;
+  public readonly processTargetAccountSMInvokeRoleArn: string;
+  public readonly waiterHandlerSSOAPIRoleArn: string;
+  public readonly waiterHandler: lambda.IFunction;
+
+  constructor(scope: Construct, id: string, buildConfig: BuildConfig) {
+    super(scope, id);
+
+    this.errorNotificationsTopic = Topic.fromTopicArn(
+      this,
+      name(buildConfig, "importedErrorNotificationsTopic"),
+      StringParameter.valueForStringParameter(
+        this,
+        name(buildConfig, "errorNotificationsTopicArn")
+      )
+    );
+
+    this.waiterHandlerNotificationsTopic = Topic.fromTopicArn(
+      this,
+      name(buildConfig, "importedWaiterHandlerNotificationsTopic"),
+      StringParameter.valueForStringParameter(
+        this,
+        name(buildConfig, "waiterHandlerNotificationsTopicArn")
+      )
+    );
+
+    this.ssoGroupEventNotificationsTopic = Topic.fromTopicArn(
+      this,
+      name(buildConfig, "importedssoGroupEventNotificationsTopic"),
+      StringParameter.valueForStringParameter(
+        this,
+        name(buildConfig, "ssoGroupEventNotificationsTopicArn")
+      )
+    );
+
+    this.orgEventsNotificationsTopic = Topic.fromTopicArn(
+      this,
+      name(buildConfig, "importedOrgEventNotificationsTopic"),
+      StringParameter.valueForStringParameter(
+        this,
+        name(buildConfig, "orgEventsNotificationsTopicArn")
+      )
+    );
+
+    this.processTargetAccountSMTopic = Topic.fromTopicArn(
+      this,
+      name(buildConfig, "importedprocessTargetAccountSMTopic"),
+      StringParameter.valueForStringParameter(
+        this,
+        name(buildConfig, "processTargetAccountSMTopicArn")
+      )
+    );
+
+    this.nodeJsLayer = lambda.LayerVersion.fromLayerVersionArn(
+      this,
+      name(buildConfig, "importedNodeJsLayerVersion"),
+      StringParameter.valueForStringParameter(
+        this,
+        name(buildConfig, "nodeJsLayerVersionArn")
+      ).toString()
+    );
+
+    this.linksTable = Table.fromTableAttributes(
+      this,
+      name(buildConfig, "importedLinksTable"),
+      {
+        tableArn: StringParameter.valueForStringParameter(
+          this,
+          name(buildConfig, "linksTableArn")
+        ),
+        tableStreamArn: StringParameter.valueForStringParameter(
+          this,
+          name(buildConfig, "linksTableStreamArn")
+        ),
+        globalIndexes: ["awsEntityData", "groupName", "permissionSetName"],
+      }
+    );
+
+    this.provisionedLinksTable = Table.fromTableAttributes(
+      this,
+      name(buildConfig, "importedProvisionedLinksTable"),
+      {
+        tableArn: StringParameter.valueForStringParameter(
+          this,
+          name(buildConfig, "provisionedLinksTableArn")
+        ),
+        globalIndexes: ["tagKeyLookUp"],
+      }
+    );
+
+    this.permissionSetTable = Table.fromTableAttributes(
+      this,
+      name(buildConfig, "importedPermissionSetTable"),
+      {
+        tableArn: StringParameter.valueForStringParameter(
+          this,
+          name(buildConfig, "permissionSetTableArn")
+        ),
+        tableStreamArn: StringParameter.valueForStringParameter(
+          this,
+          name(buildConfig, "permissionSetTableStreamArn")
+        ),
+      }
+    );
+
+    this.permissionSetArnTable = Table.fromTableArn(
+      this,
+      name(buildConfig, "importedPermissionSetArnTable"),
+      StringParameter.valueForStringParameter(
+        this,
+        name(buildConfig, "permissionSetArnTableArn")
+      )
+    );
+
+    this.snsTopicsKey = Key.fromKeyArn(
+      this,
+      name(buildConfig, "importedSnsTopicsKey"),
+      StringParameter.valueForStringParameter(
+        this,
+        name(buildConfig, "snsTopicsKeyArn")
+      )
+    );
+    this.ddbTablesKey = Key.fromKeyArn(
+      this,
+      name(buildConfig, "importedDdbTablesKey"),
+      StringParameter.valueForStringParameter(
+        this,
+        name(buildConfig, "ddbTablesKeyArn")
+      )
+    );
+
+    this.permissionSetHandlerSSOAPIRoleArn = new SSMParamReader(
+      this,
+      name(buildConfig, "permissionSetHandlerSSOAPIRoleArnpr"),
+      buildConfig,
+      {
+        ParamAccountId: buildConfig.PipelineSettings.SSOServiceAccountId,
+        ParamRegion: buildConfig.PipelineSettings.SSOServiceAccountRegion,
+        ParamNameKey: "permissionSetHandler-ssoapi-roleArn",
+        LambdaLayers: this.nodeJsLayer,
+      }
+    ).paramValue;
+
+    this.linkManagerHandlerSSOAPIRoleArn = new SSMParamReader(
+      this,
+      name(buildConfig, "linkManagerHandlerSSOAPIRoleArnpr"),
+      buildConfig,
+      {
+        ParamAccountId: buildConfig.PipelineSettings.SSOServiceAccountId,
+        ParamRegion: buildConfig.PipelineSettings.SSOServiceAccountRegion,
+        ParamNameKey: "linkManagerHandler-ssoapi-roleArn",
+        LambdaLayers: this.nodeJsLayer,
+      }
+    ).paramValue;
+
+    this.listInstancesSSOAPIRoleArn = new SSMParamReader(
+      this,
+      name(buildConfig, "listInstancesSSOAPIRoleArnpr"),
+      buildConfig,
+      {
+        ParamAccountId: buildConfig.PipelineSettings.SSOServiceAccountId,
+        ParamRegion: buildConfig.PipelineSettings.SSOServiceAccountRegion,
+        ParamNameKey: "listInstances-ssoapi-roleArn",
+        LambdaLayers: this.nodeJsLayer,
+      }
+    ).paramValue;
+
+    this.listGroupsIdentityStoreAPIRoleArn = new SSMParamReader(
+      this,
+      name(buildConfig, "listGroupsIdentityStoreAPIRoleArnpr"),
+      buildConfig,
+      {
+        ParamAccountId: buildConfig.PipelineSettings.SSOServiceAccountId,
+        ParamRegion: buildConfig.PipelineSettings.SSOServiceAccountRegion,
+        ParamNameKey: "listgroups-identitystoreapi-roleArn",
+        LambdaLayers: this.nodeJsLayer,
+      }
+    ).paramValue;
+
+    this.processTargetAccountSMInvokeRoleArn = new SSMParamReader(
+      this,
+      name(buildConfig, "processTargetAccountSMInvokeRoleArnpr"),
+      buildConfig,
+      {
+        ParamAccountId: buildConfig.PipelineSettings.OrgMainAccountId,
+        ParamRegion: "us-east-1",
+        ParamNameKey: "processTargetAccountSMInvoke-orgapi-roleArn",
+        LambdaLayers: this.nodeJsLayer,
+      }
+    ).paramValue;
+
+    this.waiterHandler = lambda.Function.fromFunctionArn(
+      this,
+      name(buildConfig, "importedWaiterHandler"),
+      StringParameter.valueForStringParameter(
+        this,
+        name(buildConfig, "waiterHandlerArn")
+      )
+    );
+
+    this.waiterHandlerSSOAPIRoleArn = StringParameter.valueForStringParameter(
+      this,
+      name(buildConfig, "waiterHandlerSSOAPIRoleArn")
+    );
+  }
+}

--- a/lib/constructs/fetch-cross-stack-values.ts
+++ b/lib/constructs/fetch-cross-stack-values.ts
@@ -219,7 +219,7 @@ export class FetchCrossStackValues extends Construct {
       buildConfig,
       {
         ParamAccountId: buildConfig.PipelineSettings.OrgMainAccountId,
-        ParamRegion: "us-east-1",
+        ParamRegion: "us-east-1", // Organizations discovery can only be done in us-east-1, hence the step functions and related roles are declared in that region
         ParamNameKey: "processTargetAccountSMInvoke-orgapi-roleArn",
         LambdaLayers: this.nodeJsLayer,
       }

--- a/lib/constructs/independent-utlity.ts
+++ b/lib/constructs/independent-utlity.ts
@@ -13,6 +13,7 @@ import {
 } from "aws-cdk-lib/aws-s3";
 import { Topic } from "aws-cdk-lib/aws-sns";
 import { EmailSubscription } from "aws-cdk-lib/aws-sns-subscriptions";
+import { StringParameter } from "aws-cdk-lib/aws-ssm";
 import { Construct } from "constructs";
 import { BuildConfig } from "../build/buildConfig";
 import { SSMParamReader } from "./ssm-param-reader";
@@ -29,11 +30,6 @@ export class IndependentUtility extends Construct {
   public readonly errorNotificationsTopic: Topic;
   public readonly ssoArtefactsBucket: Bucket;
   public readonly waiterHandlerSSOAPIRoleArn: string;
-  public readonly permissionSetHandlerSSOAPIRoleArn: string;
-  public readonly linkManagerHandlerSSOAPIRoleArn: string;
-  public readonly listInstancesSSOAPIRoleArn: string;
-  public readonly listGroupsIdentityStoreAPIRoleArn: string;
-  public readonly processTargetAccountSMInvokeRoleArn: string;
   public readonly ddbTablesKey: Key;
   public readonly s3ArtefactsKey: Key;
   public readonly snsTopicsKey: Key;
@@ -126,64 +122,24 @@ export class IndependentUtility extends Construct {
       }
     ).paramValue;
 
-    this.permissionSetHandlerSSOAPIRoleArn = new SSMParamReader(
-      this,
-      name(buildConfig, "permissionSetHandlerSSOAPIRoleArnpr"),
-      buildConfig,
-      {
-        ParamAccountId: buildConfig.PipelineSettings.SSOServiceAccountId,
-        ParamRegion: buildConfig.PipelineSettings.SSOServiceAccountRegion,
-        ParamNameKey: "permissionSetHandler-ssoapi-roleArn",
-        LambdaLayers: independentUtilityProps.nodeJsLayer,
-      }
-    ).paramValue;
+    new StringParameter(this, name(buildConfig, "errorNotificationsTopicArn"), {
+      parameterName: name(buildConfig, "errorNotificationsTopicArn"),
+      stringValue: this.errorNotificationsTopic.topicArn,
+    });
 
-    this.linkManagerHandlerSSOAPIRoleArn = new SSMParamReader(
-      this,
-      name(buildConfig, "linkManagerHandlerSSOAPIRoleArnpr"),
-      buildConfig,
-      {
-        ParamAccountId: buildConfig.PipelineSettings.SSOServiceAccountId,
-        ParamRegion: buildConfig.PipelineSettings.SSOServiceAccountRegion,
-        ParamNameKey: "linkManagerHandler-ssoapi-roleArn",
-        LambdaLayers: independentUtilityProps.nodeJsLayer,
-      }
-    ).paramValue;
+    new StringParameter(this, name(buildConfig, "snsTopicsKeyArn"), {
+      parameterName: name(buildConfig, "snsTopicsKeyArn"),
+      stringValue: this.snsTopicsKey.keyArn,
+    });
 
-    this.listInstancesSSOAPIRoleArn = new SSMParamReader(
-      this,
-      name(buildConfig, "listInstancesSSOAPIRoleArnpr"),
-      buildConfig,
-      {
-        ParamAccountId: buildConfig.PipelineSettings.SSOServiceAccountId,
-        ParamRegion: buildConfig.PipelineSettings.SSOServiceAccountRegion,
-        ParamNameKey: "listInstances-ssoapi-roleArn",
-        LambdaLayers: independentUtilityProps.nodeJsLayer,
-      }
-    ).paramValue;
+    new StringParameter(this, name(buildConfig, "ddbTablesKeyArn"), {
+      parameterName: name(buildConfig, "ddbTablesKeyArn"),
+      stringValue: this.ddbTablesKey.keyArn,
+    });
 
-    this.listGroupsIdentityStoreAPIRoleArn = new SSMParamReader(
-      this,
-      name(buildConfig, "listGroupsIdentityStoreAPIRoleArnpr"),
-      buildConfig,
-      {
-        ParamAccountId: buildConfig.PipelineSettings.SSOServiceAccountId,
-        ParamRegion: buildConfig.PipelineSettings.SSOServiceAccountRegion,
-        ParamNameKey: "listgroups-identitystoreapi-roleArn",
-        LambdaLayers: independentUtilityProps.nodeJsLayer,
-      }
-    ).paramValue;
-
-    this.processTargetAccountSMInvokeRoleArn = new SSMParamReader(
-      this,
-      name(buildConfig, "processTargetAccountSMInvokeRoleArnpr"),
-      buildConfig,
-      {
-        ParamAccountId: buildConfig.PipelineSettings.OrgMainAccountId,
-        ParamRegion: "us-east-1",
-        ParamNameKey: "processTargetAccountSMInvoke-orgapi-roleArn",
-        LambdaLayers: independentUtilityProps.nodeJsLayer,
-      }
-    ).paramValue;
+    new StringParameter(this, name(buildConfig, "waiterHandlerSSOAPIRoleArn"), {
+      parameterName: name(buildConfig, "waiterHandlerSSOAPIRoleArn"),
+      stringValue: this.waiterHandlerSSOAPIRoleArn,
+    });
   }
 }

--- a/lib/constructs/lambda-layers.ts
+++ b/lib/constructs/lambda-layers.ts
@@ -3,6 +3,7 @@ Lambda layers construct
 */
 
 import { Code, LayerVersion, Runtime } from "aws-cdk-lib/aws-lambda";
+import { StringParameter } from "aws-cdk-lib/aws-ssm";
 import { Construct } from "constructs";
 import { join } from "path";
 import { BuildConfig } from "../build/buildConfig";
@@ -29,6 +30,11 @@ export class LambdaLayers extends Construct {
       }
     );
 
+    new StringParameter(this, name(buildConfig, "nodeJsLayerVersionArn"), {
+      parameterName: name(buildConfig, "nodeJsLayerVersionArn"),
+      stringValue: this.nodeJsLayer.layerVersionArn,
+    });
+
     this.pythonLayer = new LayerVersion(
       this,
       name(buildConfig, "pythonLayer"),
@@ -39,5 +45,10 @@ export class LambdaLayers extends Construct {
         compatibleRuntimes: [Runtime.PYTHON_3_8],
       }
     );
+
+    new StringParameter(this, name(buildConfig, "pythonLayerVersionArn"), {
+      parameterName: name(buildConfig, "pythonLayerVersionArn"),
+      stringValue: this.pythonLayer.layerVersionArn,
+    });
   }
 }

--- a/lib/constructs/link-crud.ts
+++ b/lib/constructs/link-crud.ts
@@ -23,6 +23,7 @@ import { Construct } from "constructs";
 import { join } from "path";
 import { BuildConfig } from "../build/buildConfig";
 import { LambdaProxyAPI } from "./lambda-proxy-api";
+import { StringParameter } from "aws-cdk-lib/aws-ssm";
 
 function name(buildConfig: BuildConfig, resourcename: string): string {
   return buildConfig.Environment + "-" + resourcename;
@@ -261,5 +262,19 @@ export class LinkCRUD extends Construct {
         value: `s3://${linkCRUDProps.ssoArtefactsBucket.bucketName}/links_data/`,
       });
     }
+    new StringParameter(this, name(buildConfig, "linksTableArn"), {
+      parameterName: name(buildConfig, "linksTableArn"),
+      stringValue: this.linksTable.tableArn,
+    });
+
+    new StringParameter(this, name(buildConfig, "linksTableStreamArn"), {
+      parameterName: name(buildConfig, "linksTableStreamArn"),
+      stringValue: this.linksTable.tableStreamArn?.toString() + "",
+    });
+
+    new StringParameter(this, name(buildConfig, "provisionedLinksTableArn"), {
+      parameterName: name(buildConfig, "provisionedLinksTableArn"),
+      stringValue: this.provisionedLinksTable.tableArn,
+    });
   }
 }

--- a/lib/constructs/link-processor.ts
+++ b/lib/constructs/link-processor.ts
@@ -3,10 +3,10 @@ composite construct that sets up all resources
 for links life cycle provisionings
 */
 
-import { Table } from "aws-cdk-lib/aws-dynamodb";
-import { Key } from "aws-cdk-lib/aws-kms";
+import { ITable } from "aws-cdk-lib/aws-dynamodb";
+import { IKey } from "aws-cdk-lib/aws-kms";
 import {
-  LayerVersion,
+  ILayerVersion,
   Runtime,
   StartingPosition,
 } from "aws-cdk-lib/aws-lambda";
@@ -26,7 +26,7 @@ function name(buildConfig: BuildConfig, resourcename: string): string {
 }
 
 export interface LinkProcessProps {
-  readonly linksTable: Table;
+  readonly linksTable: ITable;
   readonly provisionedLinksTableName: string;
   readonly groupsTableName: string;
   readonly permissionSetArnTableName: string;
@@ -37,8 +37,8 @@ export interface LinkProcessProps {
   readonly listGroupsIdentityStoreAPIRoleArn: string;
   readonly processTargetAccountSMInvokeRoleArn: string;
   readonly processTargetAccountSMTopic: ITopic;
-  readonly nodeJsLayer: LayerVersion;
-  readonly snsTopicsKey: Key;
+  readonly nodeJsLayer: ILayerVersion;
+  readonly snsTopicsKey: IKey;
 }
 
 export class LinkProcessor extends Construct {

--- a/lib/constructs/link-processor.ts
+++ b/lib/constructs/link-processor.ts
@@ -3,13 +3,13 @@ composite construct that sets up all resources
 for links life cycle provisionings
 */
 
-import { ITable } from "aws-cdk-lib/aws-dynamodb";
-import { IKey } from "aws-cdk-lib/aws-kms";
+import { ITable } from "aws-cdk-lib/aws-dynamodb"; // Importing external resources in CDK would use interfaces and not base objects
+import { IKey } from "aws-cdk-lib/aws-kms"; // Importing external resources in CDK would use interfaces and not base objects
 import {
   ILayerVersion,
   Runtime,
   StartingPosition,
-} from "aws-cdk-lib/aws-lambda";
+} from "aws-cdk-lib/aws-lambda"; // Importing external resources in CDK would use interfaces and not base objects
 import {
   DynamoEventSource,
   SnsDlq,

--- a/lib/constructs/org-events.ts
+++ b/lib/constructs/org-events.ts
@@ -3,7 +3,7 @@ composite construct that sets up all resources
 for org events handling
 */
 
-import { LayerVersion, Runtime } from "aws-cdk-lib/aws-lambda";
+import { ILayerVersion, Runtime } from "aws-cdk-lib/aws-lambda";
 import { SnsEventSource } from "aws-cdk-lib/aws-lambda-event-sources";
 import { NodejsFunction } from "aws-cdk-lib/aws-lambda-nodejs";
 import { ITopic } from "aws-cdk-lib/aws-sns";
@@ -21,7 +21,7 @@ export interface OrgEventsProps {
   readonly groupsTableName: string;
   readonly linkManagerTopicArn: string;
   readonly errorNotificationsTopicArn: string;
-  readonly nodeJsLayer: LayerVersion;
+  readonly nodeJsLayer: ILayerVersion;
   readonly orgEventsNotificationTopic: ITopic;
   readonly listInstancesSSOAPIRoleArn: string;
   readonly listGroupsIdentityStoreAPIRoleArn: string;

--- a/lib/constructs/org-events.ts
+++ b/lib/constructs/org-events.ts
@@ -3,10 +3,10 @@ composite construct that sets up all resources
 for org events handling
 */
 
-import { ILayerVersion, Runtime } from "aws-cdk-lib/aws-lambda";
+import { ILayerVersion, Runtime } from "aws-cdk-lib/aws-lambda"; // Importing external resources in CDK would use interfaces and not base objects
 import { SnsEventSource } from "aws-cdk-lib/aws-lambda-event-sources";
 import { NodejsFunction } from "aws-cdk-lib/aws-lambda-nodejs";
-import { ITopic } from "aws-cdk-lib/aws-sns";
+import { ITopic } from "aws-cdk-lib/aws-sns"; // Importing external resources in CDK would use interfaces and not base objects
 import { Construct } from "constructs";
 import { join } from "path";
 import { BuildConfig } from "../build/buildConfig";

--- a/lib/constructs/permission-set-crud.ts
+++ b/lib/constructs/permission-set-crud.ts
@@ -23,6 +23,7 @@ import { Construct } from "constructs";
 import { join } from "path";
 import { BuildConfig } from "../build/buildConfig";
 import { LambdaProxyAPI } from "./lambda-proxy-api";
+import { StringParameter } from "aws-cdk-lib/aws-ssm";
 
 function name(buildConfig: BuildConfig, resourcename: string): string {
   return buildConfig.Environment + "-" + resourcename;
@@ -246,5 +247,24 @@ export class PermissionSetCRUD extends Construct {
         value: `s3://${PermissionSetCRUDProps.ssoArtefactsBucket.bucketName}/permission_sets/`,
       });
     }
+
+    new StringParameter(this, name(buildConfig, "permissionSetTableArn"), {
+      parameterName: name(buildConfig, "permissionSetTableArn"),
+      stringValue: this.permissionSetTable.tableArn,
+    });
+
+    new StringParameter(
+      this,
+      name(buildConfig, "permissionSetTableStreamArn"),
+      {
+        parameterName: name(buildConfig, "permissionSetTableStreamArn"),
+        stringValue: this.permissionSetTable.tableStreamArn?.toString() + "",
+      }
+    );
+
+    new StringParameter(this, name(buildConfig, "permissionSetArnTableArn"), {
+      parameterName: name(buildConfig, "permissionSetArnTableArn"),
+      stringValue: this.permissionSetArnTable.tableArn,
+    });
   }
 }

--- a/lib/constructs/permission-set-processor.ts
+++ b/lib/constructs/permission-set-processor.ts
@@ -3,10 +3,9 @@ composite construct that sets up all resources
 for permission set life cycle provisioning
 */
 
-import { Table } from "aws-cdk-lib/aws-dynamodb";
-import { Key } from "aws-cdk-lib/aws-kms";
+import { ITable } from "aws-cdk-lib/aws-dynamodb";
+import { IKey } from "aws-cdk-lib/aws-kms";
 import * as lambda from "aws-cdk-lib/aws-lambda"; //Needed to avoid semgrep throwing up https://cwe.mitre.org/data/definitions/95.html
-import { LayerVersion, Runtime } from "aws-cdk-lib/aws-lambda";
 import {
   DynamoEventSource,
   SnsDlq,
@@ -23,8 +22,8 @@ function name(buildConfig: BuildConfig, resourcename: string): string {
 }
 
 export interface PermissionSetProcessProps {
-  readonly nodeJsLayer: LayerVersion;
-  readonly permissionSetTable: Table;
+  readonly nodeJsLayer: lambda.ILayerVersion;
+  readonly permissionSetTable: ITable;
   readonly PermissionSetArnTableName: string;
   readonly errorNotificationsTopic: ITopic;
   readonly waiterHandlerNotificationsTopicArn: string;
@@ -36,7 +35,7 @@ export interface PermissionSetProcessProps {
   readonly listGroupsIdentityStoreAPIRoleArn: string;
   readonly processTargetAccountSMInvokeRoleArn: string;
   readonly processTargetAccountSMTopic: ITopic;
-  readonly snsTopicsKey: Key;
+  readonly snsTopicsKey: IKey;
 }
 
 export class PermissionSetProcessor extends Construct {
@@ -114,7 +113,7 @@ export class PermissionSetProcessor extends Construct {
       name(buildConfig, "permissionSetHandler"),
       {
         functionName: name(buildConfig, "permissionSetHandler"),
-        runtime: Runtime.NODEJS_14_X,
+        runtime: lambda.Runtime.NODEJS_14_X,
         entry: join(
           __dirname,
           "../",
@@ -158,7 +157,7 @@ export class PermissionSetProcessor extends Construct {
       this,
       name(buildConfig, "permissionSetSyncHandler"),
       {
-        runtime: Runtime.NODEJS_14_X,
+        runtime: lambda.Runtime.NODEJS_14_X,
         functionName: name(buildConfig, "permissionSetSyncHandler"),
         entry: join(
           __dirname,

--- a/lib/constructs/permission-set-processor.ts
+++ b/lib/constructs/permission-set-processor.ts
@@ -3,8 +3,8 @@ composite construct that sets up all resources
 for permission set life cycle provisioning
 */
 
-import { ITable } from "aws-cdk-lib/aws-dynamodb";
-import { IKey } from "aws-cdk-lib/aws-kms";
+import { ITable } from "aws-cdk-lib/aws-dynamodb"; // Importing external resources in CDK would use interfaces and not base objects
+import { IKey } from "aws-cdk-lib/aws-kms"; // Importing external resources in CDK would use interfaces and not base objects
 import * as lambda from "aws-cdk-lib/aws-lambda"; //Needed to avoid semgrep throwing up https://cwe.mitre.org/data/definitions/95.html
 import {
   DynamoEventSource,

--- a/lib/constructs/preSolution-access-manager.ts
+++ b/lib/constructs/preSolution-access-manager.ts
@@ -1,0 +1,165 @@
+/*
+All access granting within the preSolution artefacts stack is consolidated
+here to facilitate easier management and visibility
+*/
+
+import { PolicyStatement } from "aws-cdk-lib/aws-iam";
+import { Construct } from "constructs";
+import { BuildConfig } from "../build/buildConfig";
+import { IndependentUtility } from "./independent-utlity";
+import { LinkCRUD } from "./link-crud";
+import { PermissionSetCRUD } from "./permission-set-crud";
+import { Utility } from "./utility";
+
+export interface PreSolutionAccessManagerProps {
+  readonly PermissionSetCRUD: PermissionSetCRUD;
+  readonly LinkCRUD: LinkCRUD;
+  readonly Utility: Utility;
+  readonly IndependentUtility: IndependentUtility;
+}
+
+export class PreSolutionAccessManager extends Construct {
+  constructor(
+    scope: Construct,
+    id: string,
+    buildConfig: BuildConfig,
+    preSolutionAccessManagerProps: PreSolutionAccessManagerProps
+  ) {
+    super(scope, id);
+
+    // Waiter Handler access
+    preSolutionAccessManagerProps.IndependentUtility.snsTopicsKey.grantEncryptDecrypt(
+      preSolutionAccessManagerProps.Utility.waiterHandler
+    );
+    preSolutionAccessManagerProps.IndependentUtility.errorNotificationsTopic.grantPublish(
+      preSolutionAccessManagerProps.Utility.waiterHandler
+    );
+    preSolutionAccessManagerProps.IndependentUtility.ddbTablesKey.grantEncryptDecrypt(
+      preSolutionAccessManagerProps.Utility.waiterHandler
+    );
+    preSolutionAccessManagerProps.LinkCRUD.provisionedLinksTable.grantReadWriteData(
+      preSolutionAccessManagerProps.Utility.waiterHandler
+    );
+    preSolutionAccessManagerProps.Utility.waiterHandler.addToRolePolicy(
+      new PolicyStatement({
+        resources: [
+          preSolutionAccessManagerProps.IndependentUtility
+            .waiterHandlerSSOAPIRoleArn,
+        ],
+        actions: ["sts:AssumeRole"],
+      })
+    );
+
+    // Import interfaces access
+
+    if (buildConfig.Parameters.LinksProvisioningMode.toLowerCase() === "api") {
+      // Link - API interface mode
+
+      preSolutionAccessManagerProps.IndependentUtility.ddbTablesKey.grantEncryptDecrypt(
+        preSolutionAccessManagerProps.LinkCRUD.linkAPIHandler
+      );
+      preSolutionAccessManagerProps.LinkCRUD.linksTable.grantReadWriteData(
+        preSolutionAccessManagerProps.LinkCRUD.linkAPIHandler
+      );
+      preSolutionAccessManagerProps.IndependentUtility.s3ArtefactsKey.grantEncryptDecrypt(
+        preSolutionAccessManagerProps.LinkCRUD.linkAPIHandler
+      );
+      preSolutionAccessManagerProps.IndependentUtility.ssoArtefactsBucket.grantReadWrite(
+        preSolutionAccessManagerProps.LinkCRUD.linkAPIHandler
+      );
+    } else {
+      // Link - S3 interface mode
+
+      preSolutionAccessManagerProps.IndependentUtility.ddbTablesKey.grantEncryptDecrypt(
+        preSolutionAccessManagerProps.LinkCRUD.linkCuHandler
+      );
+      preSolutionAccessManagerProps.LinkCRUD.linksTable.grantReadWriteData(
+        preSolutionAccessManagerProps.LinkCRUD.linkCuHandler
+      );
+      preSolutionAccessManagerProps.IndependentUtility.ddbTablesKey.grantEncryptDecrypt(
+        preSolutionAccessManagerProps.LinkCRUD.linkDelHandler
+      );
+      preSolutionAccessManagerProps.LinkCRUD.linksTable.grantReadWriteData(
+        preSolutionAccessManagerProps.LinkCRUD.linkDelHandler
+      );
+      preSolutionAccessManagerProps.IndependentUtility.snsTopicsKey.grantEncryptDecrypt(
+        preSolutionAccessManagerProps.LinkCRUD.linkCuHandler
+      );
+      preSolutionAccessManagerProps.IndependentUtility.snsTopicsKey.grantEncryptDecrypt(
+        preSolutionAccessManagerProps.LinkCRUD.linkDelHandler
+      );
+      preSolutionAccessManagerProps.IndependentUtility.errorNotificationsTopic.grantPublish(
+        preSolutionAccessManagerProps.LinkCRUD.linkCuHandler
+      );
+      preSolutionAccessManagerProps.IndependentUtility.errorNotificationsTopic.grantPublish(
+        preSolutionAccessManagerProps.LinkCRUD.linkDelHandler
+      );
+    }
+
+    if (
+      buildConfig.Parameters.PermissionSetProvisioningMode.toLowerCase() ===
+      "api"
+    ) {
+      // PermissionSet - API interface mode
+
+      preSolutionAccessManagerProps.IndependentUtility.ddbTablesKey.grantEncryptDecrypt(
+        preSolutionAccessManagerProps.PermissionSetCRUD.permissionSetAPIHandler
+      );
+      preSolutionAccessManagerProps.LinkCRUD.linksTable.grantReadData(
+        preSolutionAccessManagerProps.PermissionSetCRUD.permissionSetAPIHandler
+      );
+      preSolutionAccessManagerProps.PermissionSetCRUD.permissionSetTable.grantReadWriteData(
+        preSolutionAccessManagerProps.PermissionSetCRUD.permissionSetAPIHandler
+      );
+      preSolutionAccessManagerProps.IndependentUtility.s3ArtefactsKey.grantEncryptDecrypt(
+        preSolutionAccessManagerProps.PermissionSetCRUD.permissionSetAPIHandler
+      );
+      preSolutionAccessManagerProps.IndependentUtility.ssoArtefactsBucket.grantReadWrite(
+        preSolutionAccessManagerProps.PermissionSetCRUD.permissionSetAPIHandler
+      );
+    } else {
+      // PermissionSet - S3 interface mode
+
+      preSolutionAccessManagerProps.IndependentUtility.snsTopicsKey.grantEncryptDecrypt(
+        preSolutionAccessManagerProps.PermissionSetCRUD.permissionSetCuHandler
+      );
+      preSolutionAccessManagerProps.IndependentUtility.errorNotificationsTopic.grantPublish(
+        preSolutionAccessManagerProps.PermissionSetCRUD.permissionSetCuHandler
+      );
+
+      preSolutionAccessManagerProps.IndependentUtility.snsTopicsKey.grantEncryptDecrypt(
+        preSolutionAccessManagerProps.PermissionSetCRUD.permissionSetDelHandler
+      );
+      preSolutionAccessManagerProps.IndependentUtility.errorNotificationsTopic.grantPublish(
+        preSolutionAccessManagerProps.PermissionSetCRUD.permissionSetDelHandler
+      );
+      preSolutionAccessManagerProps.IndependentUtility.ddbTablesKey.grantEncryptDecrypt(
+        preSolutionAccessManagerProps.PermissionSetCRUD.permissionSetCuHandler
+      );
+      preSolutionAccessManagerProps.LinkCRUD.linksTable.grantReadData(
+        preSolutionAccessManagerProps.PermissionSetCRUD.permissionSetDelHandler
+      );
+      preSolutionAccessManagerProps.PermissionSetCRUD.permissionSetTable.grantReadWriteData(
+        preSolutionAccessManagerProps.PermissionSetCRUD.permissionSetCuHandler
+      );
+      preSolutionAccessManagerProps.IndependentUtility.ddbTablesKey.grantEncryptDecrypt(
+        preSolutionAccessManagerProps.PermissionSetCRUD.permissionSetDelHandler
+      );
+      preSolutionAccessManagerProps.PermissionSetCRUD.permissionSetTable.grantReadWriteData(
+        preSolutionAccessManagerProps.PermissionSetCRUD.permissionSetDelHandler
+      );
+      preSolutionAccessManagerProps.IndependentUtility.s3ArtefactsKey.grantEncryptDecrypt(
+        preSolutionAccessManagerProps.PermissionSetCRUD.permissionSetCuHandler
+      );
+      preSolutionAccessManagerProps.IndependentUtility.ssoArtefactsBucket.grantRead(
+        preSolutionAccessManagerProps.PermissionSetCRUD.permissionSetCuHandler
+      );
+      preSolutionAccessManagerProps.IndependentUtility.s3ArtefactsKey.grantEncryptDecrypt(
+        preSolutionAccessManagerProps.PermissionSetCRUD.permissionSetDelHandler
+      );
+      preSolutionAccessManagerProps.IndependentUtility.ssoArtefactsBucket.grantRead(
+        preSolutionAccessManagerProps.PermissionSetCRUD.permissionSetDelHandler
+      );
+    }
+  }
+}

--- a/lib/constructs/ssm-param-reader.ts
+++ b/lib/constructs/ssm-param-reader.ts
@@ -3,12 +3,12 @@ Custom cloudformation resource construct that
 allows cross account read of SSM parameter value
 */
 
-import { PolicyStatement } from "aws-cdk-lib/aws-iam";
-import { LayerVersion, Runtime } from "aws-cdk-lib/aws-lambda";
-import { NodejsFunction } from "aws-cdk-lib/aws-lambda-nodejs";
 import { CustomResource } from "aws-cdk-lib";
-import { Construct } from "constructs";
+import { PolicyStatement } from "aws-cdk-lib/aws-iam";
+import { ILayerVersion, Runtime } from "aws-cdk-lib/aws-lambda";
+import { NodejsFunction } from "aws-cdk-lib/aws-lambda-nodejs";
 import { Provider } from "aws-cdk-lib/custom-resources";
+import { Construct } from "constructs";
 import { join } from "path";
 import { BuildConfig } from "../build/buildConfig";
 
@@ -20,7 +20,7 @@ export interface SSMParamReaderProps {
   readonly ParamNameKey: string;
   readonly ParamAccountId: string;
   readonly ParamRegion: string;
-  readonly LambdaLayers: LayerVersion;
+  readonly LambdaLayers: ILayerVersion;
 }
 
 export class SSMParamReader extends Construct {

--- a/lib/constructs/ssm-param-reader.ts
+++ b/lib/constructs/ssm-param-reader.ts
@@ -5,7 +5,7 @@ allows cross account read of SSM parameter value
 
 import { CustomResource } from "aws-cdk-lib";
 import { PolicyStatement } from "aws-cdk-lib/aws-iam";
-import { ILayerVersion, Runtime } from "aws-cdk-lib/aws-lambda";
+import { ILayerVersion, Runtime } from "aws-cdk-lib/aws-lambda"; // Importing external resources in CDK would use interfaces and not base objects
 import { NodejsFunction } from "aws-cdk-lib/aws-lambda-nodejs";
 import { Provider } from "aws-cdk-lib/custom-resources";
 import { Construct } from "constructs";

--- a/lib/constructs/sso-group-crud.ts
+++ b/lib/constructs/sso-group-crud.ts
@@ -10,7 +10,7 @@ import {
   Table,
   TableEncryption,
 } from "aws-cdk-lib/aws-dynamodb";
-import { IKey } from "aws-cdk-lib/aws-kms";
+import { IKey } from "aws-cdk-lib/aws-kms"; // Importing external resources in CDK would use interfaces and not base objects
 import { Construct } from "constructs";
 import { BuildConfig } from "../build/buildConfig";
 

--- a/lib/constructs/sso-group-crud.ts
+++ b/lib/constructs/sso-group-crud.ts
@@ -3,14 +3,14 @@ composite construct that sets up all resources
 for SSO group import event notifications
 */
 
+import { RemovalPolicy } from "aws-cdk-lib";
 import {
   AttributeType,
   BillingMode,
   Table,
   TableEncryption,
 } from "aws-cdk-lib/aws-dynamodb";
-import { Key } from "aws-cdk-lib/aws-kms";
-import { RemovalPolicy } from "aws-cdk-lib";
+import { IKey } from "aws-cdk-lib/aws-kms";
 import { Construct } from "constructs";
 import { BuildConfig } from "../build/buildConfig";
 
@@ -19,7 +19,7 @@ function name(buildConfig: BuildConfig, resourcename: string): string {
 }
 
 export interface SSOGroupCrudProps {
-  readonly ddbTablesKey: Key;
+  readonly ddbTablesKey: IKey;
 }
 
 export class SSOGroupCRUD extends Construct {

--- a/lib/constructs/sso-group-processor.ts
+++ b/lib/constructs/sso-group-processor.ts
@@ -2,7 +2,7 @@
 composite construct that sets up all resources
 for SSO group life cycle notifications
 */
-import { LayerVersion, Runtime } from "aws-cdk-lib/aws-lambda";
+import { ILayerVersion, Runtime } from "aws-cdk-lib/aws-lambda";
 import { SnsEventSource } from "aws-cdk-lib/aws-lambda-event-sources";
 import { NodejsFunction } from "aws-cdk-lib/aws-lambda-nodejs";
 import { ITopic } from "aws-cdk-lib/aws-sns";
@@ -20,7 +20,7 @@ export interface SSOGroupProcessorProps {
   readonly groupsTableName: string;
   readonly linkManagerTopicArn: string;
   readonly errorNotificationsTopicArn: string;
-  readonly nodeJsLayer: LayerVersion;
+  readonly nodeJsLayer: ILayerVersion;
   readonly ssoGroupEventNotificationsTopic: ITopic;
   readonly listInstancesSSOAPIRoleArn: string;
   readonly processTargetAccountSMInvokeRoleArn: string;

--- a/lib/constructs/sso-group-processor.ts
+++ b/lib/constructs/sso-group-processor.ts
@@ -2,10 +2,10 @@
 composite construct that sets up all resources
 for SSO group life cycle notifications
 */
-import { ILayerVersion, Runtime } from "aws-cdk-lib/aws-lambda";
+import { ILayerVersion, Runtime } from "aws-cdk-lib/aws-lambda"; // Importing external resources in CDK would use interfaces and not base objects
 import { SnsEventSource } from "aws-cdk-lib/aws-lambda-event-sources";
 import { NodejsFunction } from "aws-cdk-lib/aws-lambda-nodejs";
-import { ITopic } from "aws-cdk-lib/aws-sns";
+import { ITopic } from "aws-cdk-lib/aws-sns"; // Importing external resources in CDK would use interfaces and not base objects
 import { Construct } from "constructs";
 import { join } from "path";
 import { BuildConfig } from "../build/buildConfig";

--- a/lib/constructs/utility.ts
+++ b/lib/constructs/utility.ts
@@ -8,6 +8,7 @@ import { Key } from "aws-cdk-lib/aws-kms";
 import * as lambda from "aws-cdk-lib/aws-lambda";
 import { SnsEventSource } from "aws-cdk-lib/aws-lambda-event-sources";
 import { ITopic, Topic } from "aws-cdk-lib/aws-sns";
+import { StringParameter } from "aws-cdk-lib/aws-ssm";
 import { Construct } from "constructs";
 import { join } from "path";
 import { BuildConfig } from "../build/buildConfig";
@@ -123,5 +124,46 @@ export class Utility extends Construct {
     this.waiterHandler.addEventSource(
       new SnsEventSource(this.waiterHandlerNotificationsTopic)
     );
+
+    new StringParameter(
+      this,
+      name(buildConfig, "waiterHandlerNotificationsTopicArn"),
+      {
+        parameterName: name(buildConfig, "waiterHandlerNotificationsTopicArn"),
+        stringValue: this.waiterHandlerNotificationsTopic.topicArn,
+      }
+    );
+
+    new StringParameter(
+      this,
+      name(buildConfig, "processTargetAccountSMTopicArn"),
+      {
+        parameterName: name(buildConfig, "processTargetAccountSMTopicArn"),
+        stringValue: this.processTargetAccountSMTopic.topicArn,
+      }
+    );
+
+    new StringParameter(
+      this,
+      name(buildConfig, "ssoGroupEventNotificationsTopicArn"),
+      {
+        parameterName: name(buildConfig, "ssoGroupEventNotificationsTopicArn"),
+        stringValue: this.ssoGroupEventsNotificationsTopic.topicArn,
+      }
+    );
+
+    new StringParameter(
+      this,
+      name(buildConfig, "orgEventsNotificationsTopicArn"),
+      {
+        parameterName: name(buildConfig, "orgEventsNotificationsTopicArn"),
+        stringValue: this.orgEventsNotificationsTopic.topicArn,
+      }
+    );
+
+    new StringParameter(this, name(buildConfig, "waiterHandlerArn"), {
+      parameterName: name(buildConfig, "waiterHandlerArn"),
+      stringValue: this.waiterHandler.functionArn,
+    });
   }
 }

--- a/lib/stacks/pipeline/pipeline-stages.ts
+++ b/lib/stacks/pipeline/pipeline-stages.ts
@@ -103,16 +103,7 @@ export class SolutionArtefactsDeploymentStage extends Stage {
           qualifier: buildConfig.PipelineSettings.BootstrapQualifier,
         }),
       },
-      buildConfig,
-      {
-        deployIndependentUtility:
-          preSolutionArtefactsStack.deployIndependentUtility,
-        deployLambdaLayers: preSolutionArtefactsStack.deployLambdaLayers,
-        deployLinkCRUD: preSolutionArtefactsStack.deployLinkCRUD,
-        deployUtility: preSolutionArtefactsStack.deployUtility,
-        deployPermissionSetCRUD:
-          preSolutionArtefactsStack.deployPermissionSetCRUD,
-      }
+      buildConfig
     );
 
     solutionartefactsStack.node.addDependency(preSolutionArtefactsStack);

--- a/lib/stacks/pipelineStageStacks/pre-solution-artefacts.ts
+++ b/lib/stacks/pipelineStageStacks/pre-solution-artefacts.ts
@@ -10,6 +10,7 @@ import { IndependentUtility } from "../../constructs/independent-utlity";
 import { LambdaLayers } from "../../constructs/lambda-layers";
 import { LinkCRUD } from "../../constructs/link-crud";
 import { PermissionSetCRUD } from "../../constructs/permission-set-crud";
+import { PreSolutionAccessManager } from "../../constructs/preSolution-access-manager";
 import { Utility } from "../../constructs/utility";
 
 function name(buildConfig: BuildConfig, resourcename: string): string {
@@ -87,6 +88,18 @@ export class PreSolutionArtefacts extends Stack {
         ssoArtefactsBucket: this.deployIndependentUtility.ssoArtefactsBucket,
         ddbTablesKey: this.deployIndependentUtility.ddbTablesKey,
         logsKey: this.deployIndependentUtility.logsKey,
+      }
+    );
+
+    new PreSolutionAccessManager(
+      this,
+      name(buildConfig, "preSolutionAccessManager"),
+      buildConfig,
+      {
+        IndependentUtility: this.deployIndependentUtility,
+        LinkCRUD: this.deployLinkCRUD,
+        PermissionSetCRUD: this.deployPermissionSetCRUD,
+        Utility: this.deployUtility,
       }
     );
   }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Currently, target account deployment creates intrinsic dependencies between `preSolution-artefacts` stack and `solution-artefacts` stack by referencing interface properties at the code level. This resulted in CDK defining these references as stack exports creating circular dependencies.

This PR refactors this by explicitly defining all cross stack references through SSM parameters, thereby allowing the resources to be updated. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
