### PR TITLE
Fix S3 interface bugs for permission set operations; update README wi…

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 
 - [Detailed Building Blocks Overview](docs/documentation/Building-Blocks.md)
 - [Use case Flows](docs/documentation/Use-Case-Flows.md)
-- [Payload Schema Details](#payload-schema-details)
+- [Payload Schema Details for account assignments and permission sets](#payload-schema-details-for-account-assignments-and-permission-sets)
 - [Using API interface for your use cases](#using-api-interface-for-your-use-cases)
 - [Using S3 interface for your use cases](#using-s3-interface-for-your-use-cases)
 - [Unicorn Rides use cases](https://catalog.us-east-1.prod.workshops.aws/v2/workshops/640b0bab-1f5e-494a-973e-4ed7919d397b/en-US/03-usecases)
@@ -283,7 +283,7 @@ The solution provides automated change access management through the following f
 - The solution enables deployment in a distributed model i.e. orgmain, deployment and target account (or) in a single account model i.e. orgmain only. It's recommended that single account model of deployment be used only for demonstration purposes
 - The solution assumes that AWS SSO is enabled in a different account other than orgmain account and has the required cross-account permissions setup to enable the functionalities. This future-proofs the solution to support the scenario when AWS SSO service releases delegated admin support similar to other services such as GuardDuty
 
-## Payload schema details
+## Payload schema details for account assignments and permission sets
 
 - For account assignment operations with API interface
   - _action_ should be exactly one of **create, delete**

--- a/README.md
+++ b/README.md
@@ -14,6 +14,10 @@
 
 - [Detailed Building Blocks Overview](docs/documentation/Building-Blocks.md)
 - [Use case Flows](docs/documentation/Use-Case-Flows.md)
+- [Payload Schema Details](#payload-schema-details)
+- [Using API interface for your use cases](#using-api-interface-for-your-use-cases)
+- [Using S3 interface for your use cases](#using-s3-interface-for-your-use-cases)
+- [Unicorn Rides use cases](https://catalog.us-east-1.prod.workshops.aws/v2/workshops/640b0bab-1f5e-494a-973e-4ed7919d397b/en-US/03-usecases)
 - [Security](#security)
 - [License](#license)
 
@@ -278,6 +282,44 @@ The solution provides automated change access management through the following f
 - The solution enables usage of friendly names in managing permission set, account assignment life cycles and would handle the translation of friendly names into internal AWS SSO GUID's automatically
 - The solution enables deployment in a distributed model i.e. orgmain, deployment and target account (or) in a single account model i.e. orgmain only. It's recommended that single account model of deployment be used only for demonstration purposes
 - The solution assumes that AWS SSO is enabled in a different account other than orgmain account and has the required cross-account permissions setup to enable the functionalities. This future-proofs the solution to support the scenario when AWS SSO service releases delegated admin support similar to other services such as GuardDuty
+
+## Payload schema details
+
+- For account assignment operations with API interface
+  - _action_ should be exactly one of **create, delete**
+  - _linkData_ should match this format: `scopetype-scopevalue-permissionsetname-principalname-principaltype.ssofile`
+- For account assignment operations with S3 interface
+  - file name should match this format: `scopetype-scopevalue-permissionsetname-principalname-principaltype.ssofile`
+  - file contents are empty i.e. empty file
+- For both interface types,
+  - `scopetype` should be exactly one of **root, ou_id, account_tag, account**
+  - `scopevalue` sould match the keyword `all` if scopetype is set to root
+  - `scopevalue` should match the organisational unit ID if scopetype is set to ou_id
+  - `scopevalue` should match `tagkey^tagvalue` convention if scopetype is set to account_tag
+  - `scopevalue` should have account number if scopetype is set to account
+  - `permissionsetname` should match permission set name
+  - `principalname` should match `displayname` if principal type is group , else it should match `username` if principal type is user
+  - `principaltype` should be exactly one of **GROUP, USER**
+- For permission set operations with API interface
+  - _action_ should be exactly one of **create, update, delete**
+- For permission set operations with S3 interface
+  - file name should match this format: `permisssionsetname.json`
+
+## Using API interface for your use cases
+
+If you chose to use `API` interface for managing your permission sets and account assignments i.e. set `LinksProvisioningMode` or `PermissionSetProvisioningMode` to `api`, then read below for usage instructions:
+
+- Refer to postman collection sample under `docs\samples\postman-collection` for account assignment and permission set operation examples
+- More details on using `API` interface are documented [here](https://catalog.us-east-1.prod.workshops.aws/v2/workshops/640b0bab-1f5e-494a-973e-4ed7919d397b/en-US/02-api)
+
+## Using S3 interface for your use cases
+
+If you chose to use `S3` interface for managing your permission sets and account assignments i.e. set `LinksProvisioningMode` or `PermissionSetProvisioningMode` to `s3`, then read below for usage instructions:
+
+- Refer to sample files under `docs\samples\links_data` for account assignment operations and `docs\samples\permission_sets` for permission set operations
+- After deploying the solution with S3 interface, navigate to `target` account and under `env-aws-sso-extensions-for-enterprise-preSolutionArtefactsStack` outputs , you will have the S3 locations for uploading your permission sets and account assignments
+- For account assignment operations, uploading a file to the S3 prefix path would map to creating an account assignment and deleting a file from the S3 prefix path would map to deleting an account assignment
+- For permission set operations, uploading a new file to the S3 prefix path would map to creating a permission set, uploading a new copy of the file would map to updating the permission set, and deleting the file would map to deleting the permission set
 
 ## Security
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 
 - [Detailed Building Blocks Overview](docs/documentation/Building-Blocks.md)
 - [Use case Flows](docs/documentation/Use-Case-Flows.md)
-- [Payload Schema Details for account assignments and permission sets](#payload-schema-details-for-account-assignments-and-permission-sets)
+- [Schema Details for account assignment and permission set operations](#schema-details-for-account-assignment-and-permission-set-operations)
 - [Using API interface for your use cases](#using-api-interface-for-your-use-cases)
 - [Using S3 interface for your use cases](#using-s3-interface-for-your-use-cases)
 - [Unicorn Rides use cases](https://catalog.us-east-1.prod.workshops.aws/v2/workshops/640b0bab-1f5e-494a-973e-4ed7919d397b/en-US/03-usecases)
@@ -283,7 +283,7 @@ The solution provides automated change access management through the following f
 - The solution enables deployment in a distributed model i.e. orgmain, deployment and target account (or) in a single account model i.e. orgmain only. It's recommended that single account model of deployment be used only for demonstration purposes
 - The solution assumes that AWS SSO is enabled in a different account other than orgmain account and has the required cross-account permissions setup to enable the functionalities. This future-proofs the solution to support the scenario when AWS SSO service releases delegated admin support similar to other services such as GuardDuty
 
-## Payload schema details for account assignments and permission sets
+## Schema details for account assignment and permission set operations
 
 - For account assignment operations with API interface
   - _action_ should be exactly one of **create, delete**

--- a/config/env.yaml
+++ b/config/env.yaml
@@ -1,7 +1,7 @@
 ---
 App: "aws-sso-extensions-for-enterprise"
 Environment: "env"
-Version: "3.0.0"
+Version: "3.0.1"
 
 PipelineSettings:
   BootstrapQualifier: "<your-bootstrap-qualifier>" # For example: 'ssoutility'

--- a/lib/constructs/fetch-cross-stack-values.ts
+++ b/lib/constructs/fetch-cross-stack-values.ts
@@ -79,7 +79,7 @@ export class FetchCrossStackValues extends Construct {
       name(buildConfig, "importedOrgEventNotificationsTopic"),
       StringParameter.valueForStringParameter(
         this,
-        name(buildConfig, "orgEventsNotificationsTopicArn")
+        name(buildConfig, "importedOrgEventsNotificationsTopicArn")
       )
     );
 
@@ -88,7 +88,7 @@ export class FetchCrossStackValues extends Construct {
       name(buildConfig, "importedprocessTargetAccountSMTopic"),
       StringParameter.valueForStringParameter(
         this,
-        name(buildConfig, "processTargetAccountSMTopicArn")
+        name(buildConfig, "importedProcessTargetAccountSMTopicArn")
       )
     );
 

--- a/lib/constructs/link-crud.ts
+++ b/lib/constructs/link-crud.ts
@@ -285,7 +285,7 @@ export class LinkCRUD extends Construct {
       );
 
       new CfnOutput(this, name(buildConfig, "links-data-location"), {
-        exportName: name(buildConfig, "links-data-location"),
+        exportName: name(buildConfig, "account-assignments-location"),
         value: `s3://${linkCRUDProps.ssoArtefactsBucket.bucketName}/links_data/`,
       });
     }

--- a/lib/constructs/observability-artefacts.ts
+++ b/lib/constructs/observability-artefacts.ts
@@ -25,9 +25,8 @@ export class ObservabilityArtefacts extends Construct {
     ];
 
     const permissionSetAPILogGroupNames: Array<string> = [
-      `/aws/lambda/${buildConfig.Environment}-permissionSetHandler`,
+      `/aws/lambda/${buildConfig.Environment}-psApiHandler`,
       `/aws/lambda/${buildConfig.Environment}-permissionSetTopicProcessor`,
-      `/aws/lambda/${buildConfig.Environment}-processTargetAccountSMListenerHandler`,
       `/aws/lambda/${buildConfig.Environment}-permissionSetSyncHandler`,
     ];
 
@@ -116,7 +115,7 @@ export class ObservabilityArtefacts extends Construct {
       {
         name: name(buildConfig, "ssoGroupTriggerFlows-getRequestDetails"),
         queryString:
-          "fields requestId, handler, relatedData, status, statusMessage, relatedData, hasRelatedRequests, sourceRequestId | sort @timestamp desc | limit 30",
+          "fields requestId, handler, relatedData, status, statusMessage, relatedData, hasRelatedRequests, sourceRequestId | sort @timestamp desc | limit 100 | filter ispresent(requestId)",
         logGroupNames: ssoGroupLogGroupNames,
       }
     );
@@ -143,7 +142,7 @@ export class ObservabilityArtefacts extends Construct {
       {
         name: name(buildConfig, "ssoUserTriggerFlows-getRequestDetails"),
         queryString:
-          "fields requestId, handler, relatedData, status, statusMessage, relatedData, hasRelatedRequests, sourceRequestId | sort @timestamp desc | limit 30",
+          "fields requestId, handler, relatedData, status, statusMessage, relatedData, hasRelatedRequests, sourceRequestId | sort @timestamp desc | limit 100 | filter ispresent(requestId)",
         logGroupNames: ssoUserLogGroupNames,
       }
     );
@@ -173,7 +172,7 @@ export class ObservabilityArtefacts extends Construct {
           "permissionSetSyncTriggerFlows-getRequestDetails"
         ),
         queryString:
-          "fields requestId, handler, relatedData, status, statusMessage, relatedData, hasRelatedRequests, sourceRequestId | sort @timestamp desc | limit 30",
+          "fields requestId, handler, relatedData, status, statusMessage, relatedData, hasRelatedRequests, sourceRequestId | sort @timestamp desc | limit 100  | filter ispresent(requestId)",
         logGroupNames: permissionSetSyncLogGroupNames,
       }
     );
@@ -203,7 +202,7 @@ export class ObservabilityArtefacts extends Construct {
       {
         name: name(buildConfig, "orgEventsTriggerFlows-getRequestDetails"),
         queryString:
-          "fields requestId, handler, relatedData, status, statusMessage, relatedData, hasRelatedRequests, sourceRequestId | sort @timestamp desc | limit 30",
+          "fields requestId, handler, relatedData, status, statusMessage, relatedData, hasRelatedRequests, sourceRequestId | sort @timestamp desc | limit 100 | filter ispresent(requestId)",
         logGroupNames: orgEventsLogGroupNames,
       }
     );

--- a/lib/constructs/permission-set-crud.ts
+++ b/lib/constructs/permission-set-crud.ts
@@ -267,7 +267,7 @@ export class PermissionSetCRUD extends Construct {
       );
 
       new CfnOutput(this, name(buildConfig, "permission-sets-location"), {
-        exportName: "permission-sets-location",
+        exportName: name(buildConfig, "permission-sets-location"),
         value: `s3://${PermissionSetCRUDProps.ssoArtefactsBucket.bucketName}/permission_sets/`,
       });
     }

--- a/lib/constructs/utility.ts
+++ b/lib/constructs/utility.ts
@@ -105,9 +105,12 @@ export class Utility extends Construct {
 
     new StringParameter(
       this,
-      name(buildConfig, "processTargetAccountSMTopicArn"),
+      name(buildConfig, "importedProcessTargetAccountSMTopicArn"),
       {
-        parameterName: name(buildConfig, "processTargetAccountSMTopicArn"),
+        parameterName: name(
+          buildConfig,
+          "importedProcessTargetAccountSMTopicArn"
+        ),
         stringValue: this.processTargetAccountSMTopic.topicArn,
       }
     );
@@ -134,7 +137,10 @@ export class Utility extends Construct {
       this,
       name(buildConfig, "orgEventsNotificationsTopicArn"),
       {
-        parameterName: name(buildConfig, "orgEventsNotificationsTopicArn"),
+        parameterName: name(
+          buildConfig,
+          "importedOrgEventsNotificationsTopicArn"
+        ),
         stringValue: this.orgEventsNotificationsTopic.topicArn,
       }
     );

--- a/lib/lambda-functions/package.json
+++ b/lib/lambda-functions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aws-sso-extensions-for-enterprise-layer",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "AWS SSO Permissions Utility Layer",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"

--- a/lib/lambda-functions/user-interface-handlers/src/linkDel.ts
+++ b/lib/lambda-functions/user-interface-handlers/src/linkDel.ts
@@ -78,7 +78,7 @@ export const handler = async (event: S3Event) => {
               TopicArn: linkProcessingTopicArn + "",
               Message: JSON.stringify({
                 linkData: fileName,
-                action: "create",
+                action: "delete",
                 requestId: requestId,
               }),
             })

--- a/lib/lambda-functions/user-interface-handlers/src/permissionSetCu.ts
+++ b/lib/lambda-functions/user-interface-handlers/src/permissionSetCu.ts
@@ -68,7 +68,7 @@ const createUpdateSchemaDefinition = JSON.parse(
       "/opt",
       "nodejs",
       "payload-schema-definitions",
-      "PermissionSet-createUpdateAPI.json"
+      "PermissionSet-createUpdateS3.json"
     )
   )
     .valueOf()
@@ -106,8 +106,7 @@ export const handler = async (event: S3Event) => {
             new GetCommand({
               TableName: DdbTable,
               Key: {
-                permissionSetName:
-                  upsertData.permissionSetData.permissionSetName,
+                permissionSetName: upsertData.permissionSetName,
               },
             })
           );
@@ -126,8 +125,7 @@ export const handler = async (event: S3Event) => {
               Message: JSON.stringify({
                 requestId: requestId,
                 action: "update",
-                permissionSetName:
-                  upsertData.permissionSetData.permissionSetName,
+                permissionSetName: upsertData.permissionSetName,
                 oldPermissionSetData: fetchPermissionSet.Item,
               }),
             })
@@ -139,8 +137,7 @@ export const handler = async (event: S3Event) => {
               Message: JSON.stringify({
                 requestId: requestId,
                 action: "create",
-                permissionSetName:
-                  upsertData.permissionSetData.permissionSetName,
+                permissionSetName: upsertData.permissionSetName,
               }),
             })
           );
@@ -149,7 +146,7 @@ export const handler = async (event: S3Event) => {
         logger({
           handler: "userInterface-permissionSetS3CreateUpdate",
           logMode: "info",
-          relatedData: upsertData.permissionSetData.permissionSetName,
+          relatedData: upsertData.permissionSetName,
           requestId: requestId,
           status: requestStatus.InProgress,
           statusMessage: `Permission Set operation is being processed`,

--- a/lib/lambda-layers/nodejs-layer/nodejs/package.json
+++ b/lib/lambda-layers/nodejs-layer/nodejs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aws-sso-extensions-for-enterprise-layer",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "AWS SSO Permissions Utility Layer",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aws-sso-extensions-for-enterprise",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "bin": {
     "aws-sso-extensions-for-enterprise": "bin/aws-sso-extensions-for-enterprise.js"
   },


### PR DESCRIPTION
*Issue #, if available:* Fixes #33, Fixes #34

*Description of changes:*

- Handle bugs with S3 interface for permission set operations
- Updated README to include details around payload schema , API and S3 interface modes
- Handle duplicate logical resource name conflicts when using single account deployment mode


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
