### PR TITLE
Fix PermissionSet samples for S3

### DIFF
--- a/docs/samples/permission_sets/Billing-ps.json
+++ b/docs/samples/permission_sets/Billing-ps.json
@@ -1,20 +1,17 @@
 {
-  "action": "create",
-  "permissionSetData": {
-    "permissionSetName": "Billing-ps",
-    "sessionDurationInMinutes": "60",
-    "relayState": "https://eu-west-1.console.aws.amazon.com/console/home?region=eu-west-1#",
-    "tags": [
-      {
-        "Key": "versionid",
-        "Value": "01"
-      },
-      {
-        "Key": "team",
-        "Value": "Accountants"
-      }
-    ],
-    "managedPoliciesArnList": ["arn:aws:iam::aws:policy/job-function/Billing"],
-    "inlinePolicyDocument": {}
-  }
+  "permissionSetName": "Billing-ps",
+  "sessionDurationInMinutes": "60",
+  "relayState": "https://eu-west-1.console.aws.amazon.com/console/home?region=eu-west-1#",
+  "tags": [
+    {
+      "Key": "versionid",
+      "Value": "01"
+    },
+    {
+      "Key": "team",
+      "Value": "Accountants"
+    }
+  ],
+  "managedPoliciesArnList": ["arn:aws:iam::aws:policy/job-function/Billing"],
+  "inlinePolicyDocument": {}
 }

--- a/docs/samples/permission_sets/CloudOperator-ps.json
+++ b/docs/samples/permission_sets/CloudOperator-ps.json
@@ -1,56 +1,53 @@
 {
-  "action": "create",
-  "permissionSetData": {
-    "permissionSetName": "CloudOperator-ps",
-    "sessionDurationInMinutes": "240",
-    "relayState": "https://eu-west-1.console.aws.amazon.com/console/home?region=eu-west-1#",
-    "tags": [
+  "permissionSetName": "CloudOperator-ps",
+  "sessionDurationInMinutes": "240",
+  "relayState": "https://eu-west-1.console.aws.amazon.com/console/home?region=eu-west-1#",
+  "tags": [
+    {
+      "Key": "versionid",
+      "Value": "01"
+    },
+    {
+      "Key": "team",
+      "Value": "CloudOperators"
+    }
+  ],
+  "managedPoliciesArnList": [
+    "arn:aws:iam::aws:policy/job-function/SystemAdministrator",
+    "arn:aws:iam::aws:policy/job-function/NetworkAdministrator"
+  ],
+  "inlinePolicyDocument": {
+    "Version": "2012-10-17",
+    "Statement": [
       {
-        "Key": "versionid",
-        "Value": "01"
+        "Action": [
+          "iam:AddRoleToInstanceProfile",
+          "iam:CreateInstanceProfile",
+          "iam:CreatePolicy",
+          "iam:CreatePolicyVersion",
+          "iam:DeleteInstanceProfile",
+          "iam:DeletePolicy",
+          "iam:DeleteRole",
+          "iam:PassRole",
+          "iam:UpdateRole",
+          "iam:DeleteRolePermissionsBoundary",
+          "iam:UpdateRoleDescription",
+          "iam:RemoveRoleFromInstanceProfile"
+        ],
+        "Resource": [
+          "arn:aws:iam::*:role/Application_*",
+          "arn:aws:iam::*:policy/Application_*",
+          "arn:aws:iam::*:instance-profile/Application_*"
+        ],
+        "Effect": "Allow",
+        "Sid": "AllowOtherIAMActions"
       },
       {
-        "Key": "team",
-        "Value": "CloudOperators"
+        "Action": ["iam:List*", "iam:Generate*", "iam:Get*", "iam:Simulate*"],
+        "Resource": "*",
+        "Effect": "Allow",
+        "Sid": "AllowReadIAMActions"
       }
-    ],
-    "managedPoliciesArnList": [
-      "arn:aws:iam::aws:policy/job-function/SystemAdministrator",
-      "arn:aws:iam::aws:policy/job-function/NetworkAdministrator"
-    ],
-    "inlinePolicyDocument": {
-      "Version": "2012-10-17",
-      "Statement": [
-        {
-          "Action": [
-            "iam:AddRoleToInstanceProfile",
-            "iam:CreateInstanceProfile",
-            "iam:CreatePolicy",
-            "iam:CreatePolicyVersion",
-            "iam:DeleteInstanceProfile",
-            "iam:DeletePolicy",
-            "iam:DeleteRole",
-            "iam:PassRole",
-            "iam:UpdateRole",
-            "iam:DeleteRolePermissionsBoundary",
-            "iam:UpdateRoleDescription",
-            "iam:RemoveRoleFromInstanceProfile"
-          ],
-          "Resource": [
-            "arn:aws:iam::*:role/Application_*",
-            "arn:aws:iam::*:policy/Application_*",
-            "arn:aws:iam::*:instance-profile/Application_*"
-          ],
-          "Effect": "Allow",
-          "Sid": "AllowOtherIAMActions"
-        },
-        {
-          "Action": ["iam:List*", "iam:Generate*", "iam:Get*", "iam:Simulate*"],
-          "Resource": "*",
-          "Effect": "Allow",
-          "Sid": "AllowReadIAMActions"
-        }
-      ]
-    }
+    ]
   }
 }

--- a/docs/samples/permission_sets/DataScientist-ps.json
+++ b/docs/samples/permission_sets/DataScientist-ps.json
@@ -1,22 +1,19 @@
 {
-  "action": "create",
-  "permissionSetData": {
-    "permissionSetName": "DataScientist-ps",
-    "sessionDurationInMinutes": "300",
-    "relayState": "https://eu-west-1.console.aws.amazon.com/console/home?region=eu-west-1#",
-    "tags": [
-      {
-        "Key": "versionid",
-        "Value": "01"
-      },
-      {
-        "Key": "team",
-        "Value": "DataScientists"
-      }
-    ],
-    "managedPoliciesArnList": [
-      "arn:aws:iam::aws:policy/job-function/DataScientist"
-    ],
-    "inlinePolicyDocument": {}
-  }
+  "permissionSetName": "DataScientist-ps",
+  "sessionDurationInMinutes": "300",
+  "relayState": "https://eu-west-1.console.aws.amazon.com/console/home?region=eu-west-1#",
+  "tags": [
+    {
+      "Key": "versionid",
+      "Value": "01"
+    },
+    {
+      "Key": "team",
+      "Value": "DataScientists"
+    }
+  ],
+  "managedPoliciesArnList": [
+    "arn:aws:iam::aws:policy/job-function/DataScientist"
+  ],
+  "inlinePolicyDocument": {}
 }

--- a/docs/samples/permission_sets/SecurityAuditor-ps.json
+++ b/docs/samples/permission_sets/SecurityAuditor-ps.json
@@ -1,20 +1,17 @@
 {
-  "action": "create",
-  "permissionSetData": {
-    "permissionSetName": "SecurityAuditor-ps",
-    "sessionDurationInMinutes": "60",
-    "relayState": "https://eu-west-1.console.aws.amazon.com/console/home?region=eu-west-1#",
-    "tags": [
-      {
-        "Key": "versionid",
-        "Value": "01"
-      },
-      {
-        "Key": "team",
-        "Value": "SecurityAuditors"
-      }
-    ],
-    "managedPoliciesArnList": ["arn:aws:iam::aws:policy/SecurityAudit"],
-    "inlinePolicyDocument": {}
-  }
+  "permissionSetName": "SecurityAuditor-ps",
+  "sessionDurationInMinutes": "60",
+  "relayState": "https://eu-west-1.console.aws.amazon.com/console/home?region=eu-west-1#",
+  "tags": [
+    {
+      "Key": "versionid",
+      "Value": "01"
+    },
+    {
+      "Key": "team",
+      "Value": "SecurityAuditors"
+    }
+  ],
+  "managedPoliciesArnList": ["arn:aws:iam::aws:policy/SecurityAudit"],
+  "inlinePolicyDocument": {}
 }

--- a/docs/samples/permission_sets/SysAdmin-ps.json
+++ b/docs/samples/permission_sets/SysAdmin-ps.json
@@ -1,109 +1,106 @@
 {
-  "action": "create",
-  "permissionSetData": {
-    "permissionSetName": "SysAdmin-ps",
-    "sessionDurationInMinutes": "240",
-    "relayState": "https://eu-west-1.console.aws.amazon.com/systems-manager/managed-instances?region=eu-west-1#",
-    "tags": [
+  "permissionSetName": "SysAdmin-ps",
+  "sessionDurationInMinutes": "240",
+  "relayState": "https://eu-west-1.console.aws.amazon.com/systems-manager/managed-instances?region=eu-west-1#",
+  "tags": [
+    {
+      "Key": "versionid",
+      "Value": "01"
+    },
+    {
+      "Key": "team",
+      "Value": "SysAdmins"
+    }
+  ],
+  "managedPoliciesArnList": [],
+  "inlinePolicyDocument": {
+    "Version": "2012-10-17",
+    "Statement": [
       {
-        "Key": "versionid",
-        "Value": "01"
+        "Sid": "SSO",
+        "Effect": "Allow",
+        "Action": [
+          "sso:ListDirectoryAssociations*",
+          "identitystore:DescribeUser"
+        ],
+        "Resource": "*"
       },
       {
-        "Key": "team",
-        "Value": "SysAdmins"
-      }
-    ],
-    "managedPoliciesArnList": [],
-    "inlinePolicyDocument": {
-      "Version": "2012-10-17",
-      "Statement": [
-        {
-          "Sid": "SSO",
-          "Effect": "Allow",
-          "Action": [
-            "sso:ListDirectoryAssociations*",
-            "identitystore:DescribeUser"
-          ],
-          "Resource": "*"
-        },
-        {
-          "Sid": "EC2",
-          "Effect": "Allow",
-          "Action": ["ec2:DescribeInstances", "ec2:GetPasswordData"],
-          "Resource": "*"
-        },
-        {
-          "Sid": "SSM",
-          "Effect": "Allow",
-          "Action": [
-            "ssm:DescribeInstanceProperties",
-            "ssm:GetCommandInvocation",
-            "ssm:GetInventorySchema"
-          ],
-          "Resource": "*"
-        },
-        {
-          "Sid": "TerminateSession",
-          "Effect": "Allow",
-          "Action": ["ssm:TerminateSession"],
-          "Resource": "*",
-          "Condition": {
-            "StringLike": {
-              "ssm:resourceTag/aws:ssmmessages:session-id": ["${aws:userName}"]
-            }
+        "Sid": "EC2",
+        "Effect": "Allow",
+        "Action": ["ec2:DescribeInstances", "ec2:GetPasswordData"],
+        "Resource": "*"
+      },
+      {
+        "Sid": "SSM",
+        "Effect": "Allow",
+        "Action": [
+          "ssm:DescribeInstanceProperties",
+          "ssm:GetCommandInvocation",
+          "ssm:GetInventorySchema"
+        ],
+        "Resource": "*"
+      },
+      {
+        "Sid": "TerminateSession",
+        "Effect": "Allow",
+        "Action": ["ssm:TerminateSession"],
+        "Resource": "*",
+        "Condition": {
+          "StringLike": {
+            "ssm:resourceTag/aws:ssmmessages:session-id": ["${aws:userName}"]
           }
-        },
-        {
-          "Sid": "SSMGetDocument",
-          "Effect": "Allow",
-          "Action": ["ssm:GetDocument"],
-          "Resource": [
-            "arn:aws:ssm:*:*:document/AWS-StartPortForwardingSession",
-            "arn:aws:ssm:*:*:document/SSM-SessionManagerRunShell"
-          ]
-        },
-        {
-          "Sid": "SSMStartSession",
-          "Effect": "Allow",
-          "Action": ["ssm:StartSession"],
-          "Resource": [
-            "arn:aws:ec2:*:*:instance/*",
-            "arn:aws:ssm:*:*:managed-instance/*",
-            "arn:aws:ssm:*:*:document/AWS-StartPortForwardingSession"
-          ],
-          "Condition": {
-            "BoolIfExists": {
-              "ssm:SessionDocumentAccessCheck": "true"
-            }
-          }
-        },
-        {
-          "Sid": "SSMSendCommand",
-          "Effect": "Allow",
-          "Action": ["ssm:SendCommand"],
-          "Resource": [
-            "arn:aws:ec2:*:*:instance/*",
-            "arn:aws:ssm:*:*:managed-instance/*",
-            "arn:aws:ssm:*:*:document/AWSSSO-CreateSSOUser"
-          ],
-          "Condition": {
-            "BoolIfExists": {
-              "ssm:SessionDocumentAccessCheck": "true"
-            }
-          }
-        },
-        {
-          "Sid": "GuiConnect",
-          "Effect": "Allow",
-          "Action": [
-            "ssm-guiconnect:CancelConnection",
-            "ssm-guiconnect:GetConnection",
-            "ssm-guiconnect:StartConnection"
-          ],
-          "Resource": "*"
         }
-      ]
-    }
+      },
+      {
+        "Sid": "SSMGetDocument",
+        "Effect": "Allow",
+        "Action": ["ssm:GetDocument"],
+        "Resource": [
+          "arn:aws:ssm:*:*:document/AWS-StartPortForwardingSession",
+          "arn:aws:ssm:*:*:document/SSM-SessionManagerRunShell"
+        ]
+      },
+      {
+        "Sid": "SSMStartSession",
+        "Effect": "Allow",
+        "Action": ["ssm:StartSession"],
+        "Resource": [
+          "arn:aws:ec2:*:*:instance/*",
+          "arn:aws:ssm:*:*:managed-instance/*",
+          "arn:aws:ssm:*:*:document/AWS-StartPortForwardingSession"
+        ],
+        "Condition": {
+          "BoolIfExists": {
+            "ssm:SessionDocumentAccessCheck": "true"
+          }
+        }
+      },
+      {
+        "Sid": "SSMSendCommand",
+        "Effect": "Allow",
+        "Action": ["ssm:SendCommand"],
+        "Resource": [
+          "arn:aws:ec2:*:*:instance/*",
+          "arn:aws:ssm:*:*:managed-instance/*",
+          "arn:aws:ssm:*:*:document/AWSSSO-CreateSSOUser"
+        ],
+        "Condition": {
+          "BoolIfExists": {
+            "ssm:SessionDocumentAccessCheck": "true"
+          }
+        }
+      },
+      {
+        "Sid": "GuiConnect",
+        "Effect": "Allow",
+        "Action": [
+          "ssm-guiconnect:CancelConnection",
+          "ssm-guiconnect:GetConnection",
+          "ssm-guiconnect:StartConnection"
+        ],
+        "Resource": "*"
+      }
+    ]
   }
 }


### PR DESCRIPTION
*Description of changes:*

PermissionSet S3 samples included "permissionSetData" and "action", which do not work, at least in my environment running v3.0.1. Removing permissionSetData and bumping its contents into the root object, and deleting "action", fixes the errors I get from using the samples.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
