### PR TITLE
Fix permission set managed policies throttling errors

### DIFF
--- a/config/env.yaml
+++ b/config/env.yaml
@@ -1,7 +1,7 @@
 ---
 App: "aws-sso-extensions-for-enterprise"
 Environment: "env"
-Version: "3.0.2"
+Version: "3.0.3"
 
 PipelineSettings:
   BootstrapQualifier: "<your-bootstrap-qualifier>" # For example: 'ssoutility'

--- a/lib/lambda-functions/application-handlers/src/permissionSetTopicProcessor.ts
+++ b/lib/lambda-functions/application-handlers/src/permissionSetTopicProcessor.ts
@@ -349,17 +349,15 @@ export const handler = async (event: SNSEvent) => {
                 case "sortedManagedPoliciesArnList-add": {
                   const changeSettoAdd: Array<string> =
                     sortedManagedPoliciesArnList;
-                  await Promise.all(
-                    changeSettoAdd.map(async (managedPolicyArn: string) => {
-                      await ssoAdminClientObject.send(
-                        new AttachManagedPolicyToPermissionSetCommand({
-                          InstanceArn: instanceArn,
-                          PermissionSetArn: permissionSetArn,
-                          ManagedPolicyArn: managedPolicyArn,
-                        })
-                      );
-                    })
-                  );
+                  for (const managedPolicyArn of changeSettoAdd) {
+                    await ssoAdminClientObject.send(
+                      new AttachManagedPolicyToPermissionSetCommand({
+                        InstanceArn: instanceArn,
+                        PermissionSetArn: permissionSetArn,
+                        ManagedPolicyArn: managedPolicyArn,
+                      })
+                    );
+                  }
                   reProvision = true;
                   logger({
                     handler: "permissionSetTopicProcessor",
@@ -374,17 +372,16 @@ export const handler = async (event: SNSEvent) => {
                 case "sortedManagedPoliciesArnList-remove": {
                   const changeSettoRemove: Array<string> =
                     oldItem.sortedManagedPoliciesArnList;
-                  await Promise.all(
-                    changeSettoRemove.map(async (managedPolicyArn: string) => {
-                      await ssoAdminClientObject.send(
-                        new DetachManagedPolicyFromPermissionSetCommand({
-                          InstanceArn: instanceArn,
-                          PermissionSetArn: permissionSetArn,
-                          ManagedPolicyArn: managedPolicyArn,
-                        })
-                      );
-                    })
-                  );
+                  for (const managedPolicyArn of changeSettoRemove) {
+                    await ssoAdminClientObject.send(
+                      new DetachManagedPolicyFromPermissionSetCommand({
+                        InstanceArn: instanceArn,
+                        PermissionSetArn: permissionSetArn,
+                        ManagedPolicyArn: managedPolicyArn,
+                      })
+                    );
+                  }
+                  reProvision = true;
                   logger({
                     handler: "permissionSetTopicProcessor",
                     logMode: "info",
@@ -393,7 +390,7 @@ export const handler = async (event: SNSEvent) => {
                     status: requestStatus.InProgress,
                     statusMessage: `PermissionSet update operation - removed managed policies`,
                   });
-                  reProvision = true;
+
                   break;
                 }
                 case "sortedManagedPoliciesArnList-update": {
@@ -421,19 +418,17 @@ export const handler = async (event: SNSEvent) => {
                     })
                   );
                   if (changeSettoRemove.length > 0) {
-                    await Promise.all(
-                      changeSettoRemove.map(
-                        async (managedPolicyArn: string) => {
-                          await ssoAdminClientObject.send(
-                            new DetachManagedPolicyFromPermissionSetCommand({
-                              InstanceArn: instanceArn,
-                              PermissionSetArn: permissionSetArn,
-                              ManagedPolicyArn: managedPolicyArn,
-                            })
-                          );
-                        }
-                      )
-                    );
+                    for (const managedPolicyArn of changeSettoRemove) {
+                      await ssoAdminClientObject.send(
+                        new DetachManagedPolicyFromPermissionSetCommand({
+                          InstanceArn: instanceArn,
+                          PermissionSetArn: permissionSetArn,
+                          ManagedPolicyArn: managedPolicyArn,
+                        })
+                      );
+                    }
+
+                    reProvision = true;
                     logger({
                       handler: "permissionSetTopicProcessor",
                       logMode: "info",
@@ -442,20 +437,18 @@ export const handler = async (event: SNSEvent) => {
                       status: requestStatus.InProgress,
                       statusMessage: `PermissionSet update operation - removed managed policies from changeSet calculated`,
                     });
-                    reProvision = true;
                   }
                   if (changeSettoAdd.length > 0) {
-                    await Promise.all(
-                      changeSettoAdd.map(async (managedPolicyArn: string) => {
-                        await ssoAdminClientObject.send(
-                          new AttachManagedPolicyToPermissionSetCommand({
-                            InstanceArn: instanceArn,
-                            PermissionSetArn: permissionSetArn,
-                            ManagedPolicyArn: managedPolicyArn,
-                          })
-                        );
-                      })
-                    );
+                    for (const managedPolicyArn of changeSettoAdd) {
+                      await ssoAdminClientObject.send(
+                        new AttachManagedPolicyToPermissionSetCommand({
+                          InstanceArn: instanceArn,
+                          PermissionSetArn: permissionSetArn,
+                          ManagedPolicyArn: managedPolicyArn,
+                        })
+                      );
+                    }
+
                     logger({
                       handler: "permissionSetTopicProcessor",
                       logMode: "info",

--- a/lib/lambda-functions/custom-waiters/src/waitUntilPermissionSetProvisioned.ts
+++ b/lib/lambda-functions/custom-waiters/src/waitUntilPermissionSetProvisioned.ts
@@ -62,7 +62,7 @@ export const waitUntilPermissionSetProvisioned = async (
     checkState
   );
   logger({
-    handler: "accountAssignmentCreationWaiter",
+    handler: "permissionSetProvisioningWaiter",
     logMode: "info",
     relatedData: `${input.ProvisionPermissionSetRequestId}`,
     requestId: requestId,

--- a/lib/lambda-functions/package.json
+++ b/lib/lambda-functions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aws-sso-extensions-for-enterprise-layer",
-  "version": "3.0.2",
+  "version": "3.0.3",
   "description": "AWS SSO Permissions Utility Layer",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aws-sso-extensions-for-enterprise",
-  "version": "3.0.2",
+  "version": "3.0.3",
   "bin": {
     "aws-sso-extensions-for-enterprise": "bin/aws-sso-extensions-for-enterprise.js"
   },


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Refactors permission set manage policies attach and detach logic to be sequential instead of parallel. This is to handle the calls being throttled


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
