### PR TITLE
Version upgrade to 3.1.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@
 - [Using S3 interface for your use cases](#using-s3-interface-for-your-use-cases)
 - [Unicorn Rides use cases](https://catalog.us-east-1.prod.workshops.aws/v2/workshops/640b0bab-1f5e-494a-973e-4ed7919d397b/en-US/03-usecases)
 - [AWS SSO Region Switch](docs/documentation//Region-Switch.md)
+- [Troubleshooting](docs/documentation/TroubleShooting.md)
 - [Security](#security)
 - [License](#license)
 

--- a/config/env.yaml
+++ b/config/env.yaml
@@ -1,7 +1,7 @@
 ---
 App: "aws-sso-extensions-for-enterprise"
 Environment: "env"
-Version: "3.1.1"
+Version: "3.1.2"
 
 PipelineSettings:
   BootstrapQualifier: "<your-bootstrap-qualifier>" # For example: 'ssoutility'

--- a/docs/documentation/Region-Switch.md
+++ b/docs/documentation/Region-Switch.md
@@ -8,7 +8,7 @@ AWS SSO service is single-region at this point of time. In some instances, custo
 - When a customer migrates AWS SSO from one region to another region, the solution only helps automate migration of permission sets and account assignments.
 - The solution assumes that identities (users/groups) are onboarded into the new region using the same naming convention. For ex, if a customer had onboarded a user with user name `alpha-user`, group with display name `beta-group` in region 1 through any of the supported identity sources, the solution assumes that the customer will onboard the user with the same user name `alpha-user` and same group display name `beta-group` in region 2. Only when this condition is met, the solution automatically migrates account assignments from region 1 to region 2.
 
-## Seqence
+## Sequence
 
 - `Discover` component of the solution is deployed in your current AWS SSO account and current AWS SSO region first. This would read all the permission sets, account assignments in your current AWS SSO region and persist them for later usage
 - The customer then manually moves the AWS SSO configuration from their current region to the new region

--- a/docs/documentation/TroubleShooting.md
+++ b/docs/documentation/TroubleShooting.md
@@ -1,0 +1,55 @@
+# Troubleshooting
+
+- The solution uses a logging convention aligned to the following data structure for all the lambda based use case flow logs written to cloud watch log groups. Trace starts from a use case trigger where it generates the request ID and all the subsequent logs until the lifecycle of this request carry over this request ID
+
+| Log Element        |                                                         Description                                                          | Mandatory |
+| ------------------ | :--------------------------------------------------------------------------------------------------------------------------: | :-------: |
+| logMode            |                           Classifies mode the log message is written in, i.e.<br>info, error, warn                           |    Yes    |
+| handler            |                                      Name of the lambda handler that generated the log                                       |    Yes    |
+| requestId          |                  UUID based request ID to collate different log entries<br>triggered from the same process                   |    No     |
+| status             | Status of the current request i.e. one of InProgress,<br>Completed, FailedWithError, FailedWithException, OnHold,<br>Aborted |    Yes    |
+| statusMessage      |                                          Details of status to provide more context                                           |    No     |
+| relatedData        |  Solution entity that the log is being written to. For ex,<br>this could be a permission set name, account assignment link   |    No     |
+| hasRelatedRequests |                       Either true/false depending on whether this request triggered<br>other requests                        |    No     |
+| sourceReqeustId    |                                   Holds the source request ID that triggered this request                                    |    No     |
+
+- The solution writes logs to the following cloud watch log groups in `target` account and region. Note that these log groups only get created after the relevant use case flow is executed. Replace `env` with your environment name
+
+| Cloudwatch log group                                  |                                                                       Related use case                                                                       |
+| ----------------------------------------------------- | :----------------------------------------------------------------------------------------------------------------------------------------------------------: |
+| /aws/lambda/env-linkApiHandler                        |                                                        Account assignment - API interface processing                                                         |
+| /aws/lambda/env-linkCuHandler                         |                                                  Account assignment - S3 interface create/update processing                                                  |
+| /aws/lambda/env-linkDelHandler                        |                                                     Account assignment - S3 interface delete processing                                                      |
+| /aws/lambda/env-linkManagerHandler                    |                                                 Account assignment - provisioning/de-provisioning operations                                                 |
+| /aws/lambda/env-linkTopicProcessor                    | Account assignment - provisioning/de-provisioning topic processor<br>that handles resolution of ou_id, root, account_tag scopes into<br>target accounts list |
+| /aws/lambda/env-processTargetAccountSMListenerHandler |               Account assignment - handles state machine outputs when the target accounts<br>for ou_id, root, account_tag scopes are resolved                |
+| /aws/lambda/env-psApiHandler                          |                                                          Permission set - API interface processing                                                           |
+| /aws/lambda/env-psCuHandler                           |                                                    Permission set - S3 interface create/update processing                                                    |
+| /aws/lambda/env-psDelHandler                          |                                                       Permissoin set - S3 interface delete processing                                                        |
+| /aws/lambda/env-permissionSetTopicProcessor           |                                                    Permission set - create/update/delete topic processor                                                     |
+| /aws/lambda/env-permissionSetSyncHandler              |                                Permission set - synchronisation of updated permission set to already provisioned<br>accounts                                 |
+| /aws/lambda/env-ssoUserHandler                        |                                                 Self sustain - SSO user creation/deletion events processing                                                  |
+| /aws/lambda/env-ssoGroupHandler                       |                                                 Self sustain - SSO group creation/deletion events processing                                                 |
+| /aws/lambda/env-orgEventsHandler                      |                                                         Self sustain - org changes events processing                                                         |
+
+- The solution deploys pre-defined `Cloud watch insights queries` in `target` account and region that allow you to access information around a use case flow easily. These queries are defined to handle most common queries. If these queries do not fit your needs, then you could tweak them to fit your requirements. Replace `env` with your environment name.
+
+| Cloudwatch Insights query name                             |                                      Purpose                                       |
+| ---------------------------------------------------------- | :--------------------------------------------------------------------------------: |
+| env-accountAssignmentAPIFlows-getRequestDetails            |  Get details of a specific request for account assignment flows via API interface  |
+| env-accountAssignmentAPIFlows-getRelatedRequestDetails     | Get details of all related requests for account assignment flows via API interface |
+| env-permissionSetAPIFlows-getRequestDetails                |    Get details of a specific request for permission set flows via API interface    |
+| env-permissionSetAPIFlows-getRelatedRequestDetails         |   Get details of all related requests for permission set flows via API interface   |
+| env-ssoGroupTriggerFlows-getRequestDetails                 |      Get details of a specific request for SSO group creation/deletion events      |
+| env-ssoGroupTriggerFlows-getRelatedRequestDetails          |     Get details of all related requests for SSO group creation/deletion events     |
+| env-ssoUserTriggerFlows-getRequestDetails                  |      Get details of a specific request for SSO user creation/deletion events       |
+| env-ssoUserTriggerFlows-getRelatedRequestDetails           |     Get details of all related requests for SSO user creation/deletion events      |
+| env-permissionSetSyncTriggerFlows-getRequestDetails        |          Get details of a specific request for permission set sync flows           |
+| env-permissionSetSyncTriggerFlows-getRelatedRequestDetails |         Get details of all related requests for permission set sync flows          |
+| env-orgEventsTriggerFlows-getRequestDetails                |                  Get details of a specific request for org events                  |
+| env-orgEventsTriggerFlows-getRelatedRequestDetails         |                 Get details of all related requests for org events                 |
+
+- For `import current SSO configuration` use cases, the solution creates the cloudwatch insights query `env-importCurrentSSOConfiguration-errors` in your `SSO service` account `SSO service` region to provide details of all the errors that the state machine ran into and suppressed when trying to import current SSO configuration into the solution
+- For `region switch` use cases, the solution creates the cloudwatch insights query `aws-sso-extensions-region-switch-discover-errors` in your `SSO service` account `SSOServiceAccountRegion` to provide details of all the errors that the state machine ran into and suppressed when trying to discover your current SSO region configuration
+- For `region switch` use cases, the solution creates the cloudwatch insights query `aws-sso-extensions-region-switch-deploy-errors` in your `SSO service` account `SSOServiceTargetAccountRegion` to provide details of all the errors that the state machine ran into and suppressed when trying to deploy the discovered SSO configuration into your new region
+- For `upgradetoV303` use cases, the solution creates the cloudwatch insights query `upgradeV303-errors` in your `target` account and region to provide details of all the errors that the state machine ran into and suppressed when trying to upgrade account assignments from old solution format to a format compatible with solution version 3.0.3 and above

--- a/lib/lambda-functions/package.json
+++ b/lib/lambda-functions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aws-sso-extensions-for-enterprise-layer",
-  "version": "3.1.1",
+  "version": "3.1.2",
   "description": "AWS SSO Permissions Utility Layer",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"

--- a/lib/lambda-layers/nodejs-layer/nodejs/package.json
+++ b/lib/lambda-layers/nodejs-layer/nodejs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aws-sso-extensions-for-enterprise-layer",
-  "version": "3.1.1",
+  "version": "3.1.2",
   "description": "AWS SSO Permissions Utility Layer",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"

--- a/lib/stacks/pipelineStageStacks/sso-import-artefacts-part1.ts
+++ b/lib/stacks/pipelineStageStacks/sso-import-artefacts-part1.ts
@@ -416,11 +416,15 @@ export class SSOImportArtefactsPart1 extends Stack {
     );
 
     /** CloudWatch insights query to debug errors, if any */
-    new CfnQueryDefinition(this, name(buildConfig, "-errors"), {
-      name: name(buildConfig, "-errors"),
-      queryString:
-        "filter @message like 'solutionError' and details.name not like 'Catchall'| sort id asc",
-      logGroupNames: [importArtefactsSMLogGroup.logGroupName],
-    });
+    new CfnQueryDefinition(
+      this,
+      name(buildConfig, "importCurrentSSOConfiguration-errors"),
+      {
+        name: name(buildConfig, "importCurrentSSOConfiguration-errors"),
+        queryString:
+          "filter @message like 'solutionError' and details.name not like 'Catchall'| sort id asc",
+        logGroupNames: [importArtefactsSMLogGroup.logGroupName],
+      }
+    );
   }
 }

--- a/lib/stacks/pipelineStageStacks/upgrade-to-v303.ts
+++ b/lib/stacks/pipelineStageStacks/upgrade-to-v303.ts
@@ -257,8 +257,8 @@ export class UpgradeToV303 extends Stack {
     upgradeV303Resource.node.addDependency(processLinkData);
 
     /** CloudWatch insights query to debug errors, if any */
-    new CfnQueryDefinition(this, name(buildConfig, "-errors"), {
-      name: name(buildConfig, "-errors"),
+    new CfnQueryDefinition(this, name(buildConfig, "upgradeV303-errors"), {
+      name: name(buildConfig, "upgradeV303-errors"),
       queryString:
         "filter @message like 'solutionError' and details.name not like 'Catchall'| sort id asc",
       logGroupNames: [upgradeSMLogGroup.logGroupName],

--- a/lib/stacks/region-switch/aws-sso-extensions-region-switch-deploy.ts
+++ b/lib/stacks/region-switch/aws-sso-extensions-region-switch-deploy.ts
@@ -3,7 +3,11 @@ import { Table } from "aws-cdk-lib/aws-dynamodb";
 import { PolicyStatement, Role, ServicePrincipal } from "aws-cdk-lib/aws-iam";
 import { Code, LayerVersion, Runtime } from "aws-cdk-lib/aws-lambda";
 import { NodejsFunction } from "aws-cdk-lib/aws-lambda-nodejs";
-import { LogGroup, RetentionDays } from "aws-cdk-lib/aws-logs";
+import {
+  CfnQueryDefinition,
+  LogGroup,
+  RetentionDays,
+} from "aws-cdk-lib/aws-logs";
 import { CfnStateMachine } from "aws-cdk-lib/aws-stepfunctions";
 import { Provider } from "aws-cdk-lib/custom-resources";
 import { Construct } from "constructs";
@@ -299,5 +303,13 @@ export class AwsSsoExtensionsRegionSwitchDeploy extends Stack {
      */
     parentSMResource.node.addDependency(rsCreatePermissionSetsHandler);
     parentSMResource.node.addDependency(updateCustomResourceHandler);
+
+    /** CloudWatch insights query to debug errors, if any */
+    new CfnQueryDefinition(this, fullname("-errors"), {
+      name: fullname("-errors"),
+      queryString:
+        "filter @message like 'solutionError' and details.name not like 'Catchall'| sort id asc",
+      logGroupNames: [deploySMLogGroup.logGroupName],
+    });
   }
 }

--- a/lib/state-machines/deploy-region-switch-objects-asl.json
+++ b/lib/state-machines/deploy-region-switch-objects-asl.json
@@ -26,7 +26,23 @@
           "IntervalSeconds": 2,
           "MaxAttempts": 2
         }
+      ],
+      "Catch": [
+        {
+          "ErrorEquals": ["States.ALL"],
+          "Next": "Catchall for outer logic",
+          "ResultPath": "$.solutionError"
+        }
       ]
+    },
+    "Catchall for outer logic": {
+      "Type": "Pass",
+      "Next": "Fail"
+    },
+    "Fail": {
+      "Type": "Fail",
+      "Error": "Deploy Region Switch AWS SSO objects failed",
+      "Cause": "Deploy Region Switch AWS SSO objects failed"
     },
     "Scan global permission sets table": {
       "Type": "Task",
@@ -43,6 +59,13 @@
           "BackoffRate": 1.5,
           "IntervalSeconds": 2,
           "MaxAttempts": 2
+        }
+      ],
+      "Catch": [
+        {
+          "ErrorEquals": ["States.ALL"],
+          "Next": "Catchall for outer logic",
+          "ResultPath": "$.solutionError"
         }
       ]
     },
@@ -71,13 +94,7 @@
               }
             ],
             "Next": "Verify if permission set creation lambda threw an exception",
-            "OutputPath": "$.Payload",
-            "Catch": [
-              {
-                "ErrorEquals": ["States.TaskFailed"],
-                "Next": "Error op"
-              }
-            ]
+            "OutputPath": "$.Payload"
           },
           "Verify if permission set creation lambda threw an exception": {
             "Type": "Choice",
@@ -85,12 +102,12 @@
               {
                 "Variable": "$.Payload.lambdaException",
                 "IsPresent": true,
-                "Next": "Error op"
+                "Next": "Catchall for inner map"
               }
             ],
             "Default": "Look up account assignments for this permission set"
           },
-          "Error op": {
+          "Catchall for inner map": {
             "Type": "Pass",
             "End": true
           },
@@ -119,6 +136,11 @@
                 "BackoffRate": 1.5,
                 "IntervalSeconds": 2,
                 "MaxAttempts": 2
+              }
+            ],
+            "Catch": [
+              {
+                "ErrorEquals": ["States.ALL"]
               }
             ]
           },
@@ -395,7 +417,14 @@
         "globalAccountAssignmentsTable.$": "$.globalAccountAssignmentsTable",
         "pageSize.$": "$.pageSize",
         "waitSeconds.$": "$.waitSeconds"
-      }
+      },
+      "Catch": [
+        {
+          "ErrorEquals": ["States.ALL"],
+          "Next": "Catchall for outer logic",
+          "ResultPath": "$.solutionError"
+        }
+      ]
     },
     "Wait for permission set throttling": {
       "Type": "Wait",
@@ -443,11 +472,21 @@
           "IntervalSeconds": 2,
           "MaxAttempts": 2
         }
+      ],
+      "Catch": [
+        {
+          "ErrorEquals": ["States.ALL"],
+          "Next": "Catchall for outer logic",
+          "ResultPath": "$.solutionError"
+        }
       ]
     },
     "Ignore Op": {
       "Type": "Pass",
-      "End": true
+      "Next": "Success"
+    },
+    "Success": {
+      "Type": "Succeed"
     }
   }
 }

--- a/lib/state-machines/import-account-assignments-asl.json
+++ b/lib/state-machines/import-account-assignments-asl.json
@@ -20,7 +20,18 @@
           "IntervalSeconds": 2,
           "MaxAttempts": 2
         }
+      ],
+      "Catch": [
+        {
+          "ErrorEquals": ["States.ALL"],
+          "Next": "Catchall error",
+          "ResultPath": "$.solutionError"
+        }
       ]
+    },
+    "Catchall error": {
+      "Type": "Pass",
+      "End": true
     },
     "Loop through account assignments": {
       "Type": "Map",
@@ -63,7 +74,18 @@
                 "IntervalSeconds": 2,
                 "MaxAttempts": 2
               }
+            ],
+            "Catch": [
+              {
+                "ErrorEquals": ["States.ALL"],
+                "Next": "Catchall error within Map",
+                "ResultPath": "$.solutionError"
+              }
             ]
+          },
+          "Catchall error within Map": {
+            "Type": "Pass",
+            "End": true
           },
           "Set groupName as entityName": {
             "Type": "Pass",
@@ -101,7 +123,14 @@
                 "MaxAttempts": 2
               }
             ],
-            "End": true
+            "End": true,
+            "Catch": [
+              {
+                "ErrorEquals": ["States.ALL"],
+                "Next": "Catchall error within Map",
+                "ResultPath": "$.solutionError"
+              }
+            ]
           },
           "DescribeUser": {
             "Type": "Task",
@@ -118,6 +147,13 @@
                 "BackoffRate": 1.5,
                 "IntervalSeconds": 2,
                 "MaxAttempts": 2
+              }
+            ],
+            "Catch": [
+              {
+                "ErrorEquals": ["States.ALL"],
+                "Next": "Catchall error within Map",
+                "ResultPath": "$.solutionError"
               }
             ]
           },
@@ -154,7 +190,14 @@
       },
       "ItemsPath": "$.listAccountAssignments.AccountAssignments",
       "ResultPath": null,
-      "Next": "Check For NextToken?"
+      "Next": "Check For NextToken?",
+      "Catch": [
+        {
+          "ErrorEquals": ["States.ALL"],
+          "Next": "Catchall error",
+          "ResultPath": "$.solutionError"
+        }
+      ]
     },
     "Check For NextToken?": {
       "Type": "Choice",
@@ -190,6 +233,13 @@
           "BackoffRate": 1.5,
           "IntervalSeconds": 2,
           "MaxAttempts": 2
+        }
+      ],
+      "Catch": [
+        {
+          "ErrorEquals": ["States.ALL"],
+          "Next": "Catchall error",
+          "ResultPath": "$.solutionError"
         }
       ]
     },

--- a/lib/state-machines/import-current-config-asl.json
+++ b/lib/state-machines/import-current-config-asl.json
@@ -16,12 +16,12 @@
               "StringEquals": "CloudFormation"
             }
           ],
-          "Next": "Pass"
+          "Next": "Catchall"
         }
       ],
       "Default": "ListInstances"
     },
-    "Pass": {
+    "Catchall": {
       "Type": "Pass",
       "End": true
     },
@@ -42,8 +42,8 @@
       "Catch": [
         {
           "ErrorEquals": ["States.ALL"],
-          "Next": "Pass",
-          "ResultPath": "$.stateMachineError"
+          "Next": "Catchall",
+          "ResultPath": "$.solutionError"
         }
       ]
     },
@@ -79,8 +79,8 @@
       "Catch": [
         {
           "ErrorEquals": ["States.ALL"],
-          "Next": "Pass",
-          "ResultPath": "$.stateMachineError"
+          "Next": "Catchall",
+          "ResultPath": "$.solutionError"
         }
       ]
     },
@@ -109,7 +109,7 @@
         {
           "ErrorEquals": ["States.ALL"],
           "Next": "Delete temporary permission sets table",
-          "ResultPath": "$.stateMachineError"
+          "ResultPath": "$.solutionError"
         }
       ]
     },
@@ -154,7 +154,7 @@
         {
           "ErrorEquals": ["States.ALL"],
           "Next": "Delete temporary permission sets table",
-          "ResultPath": "$.stateMachineError"
+          "ResultPath": "$.solutionError"
         }
       ]
     },
@@ -179,7 +179,7 @@
       "Type": "Choice",
       "Choices": [
         {
-          "Variable": "$.stateMachineError",
+          "Variable": "$.solutionError",
           "IsPresent": true,
           "Next": "State machine failed"
         }

--- a/lib/state-machines/import-permission-sets-asl.json
+++ b/lib/state-machines/import-permission-sets-asl.json
@@ -18,7 +18,23 @@
           "IntervalSeconds": 2,
           "MaxAttempts": 2
         }
+      ],
+      "Catch": [
+        {
+          "ErrorEquals": ["States.ALL"],
+          "Next": "Catchall",
+          "ResultPath": "$.solutionError"
+        }
       ]
+    },
+    "Catchall": {
+      "Type": "Pass",
+      "Next": "Fail"
+    },
+    "Fail": {
+      "Type": "Fail",
+      "Error": "Import AWS SSO Permission Sets state machine failed",
+      "Cause": "Import AWS SSO Permission Sets state machine failed"
     },
     "Loop through permission sets": {
       "Type": "Map",
@@ -41,7 +57,18 @@
                 "IntervalSeconds": 2,
                 "MaxAttempts": 2
               }
+            ],
+            "Catch": [
+              {
+                "ErrorEquals": ["States.ALL"],
+                "Next": "Catchall for error handling",
+                "ResultPath": "$.solutionError"
+              }
             ]
+          },
+          "Catchall for error handling": {
+            "Type": "Pass",
+            "End": true
           },
           "Put Permission Set": {
             "Type": "Task",
@@ -63,6 +90,13 @@
                 "IntervalSeconds": 2,
                 "MaxAttempts": 2
               }
+            ],
+            "Catch": [
+              {
+                "ErrorEquals": ["States.ALL"],
+                "Next": "Catchall for error handling",
+                "ResultPath": "$.solutionError"
+              }
             ]
           },
           "ListManagedPoliciesInPermissionSet": {
@@ -81,6 +115,13 @@
                 "BackoffRate": 1.5,
                 "IntervalSeconds": 2,
                 "MaxAttempts": 2
+              }
+            ],
+            "Catch": [
+              {
+                "ErrorEquals": ["States.ALL"],
+                "Next": "Catchall for error handling",
+                "ResultPath": "$.solutionError"
               }
             ]
           },
@@ -116,6 +157,17 @@
                       "MaxAttempts": 2
                     }
                   ],
+                  "End": true,
+                  "Catch": [
+                    {
+                      "ErrorEquals": ["States.ALL"],
+                      "Next": "Catchall for inner map",
+                      "ResultPath": "$.solutionError"
+                    }
+                  ]
+                },
+                "Catchall for inner map": {
+                  "Type": "Pass",
                   "End": true
                 }
               }
@@ -126,7 +178,14 @@
               "permissionSetArn.$": "$.permissionSetArn",
               "mp.$": "$$.Map.Item.Value.Arn"
             },
-            "ResultPath": null
+            "ResultPath": null,
+            "Catch": [
+              {
+                "ErrorEquals": ["States.ALL"],
+                "Next": "Catchall for error handling",
+                "ResultPath": "$.solutionError"
+              }
+            ]
           },
           "Are there more managed policies?": {
             "Type": "Choice",
@@ -157,6 +216,13 @@
                 "IntervalSeconds": 2,
                 "MaxAttempts": 2
               }
+            ],
+            "Catch": [
+              {
+                "ErrorEquals": ["States.ALL"],
+                "Next": "Catchall for error handling",
+                "ResultPath": "$.solutionError"
+              }
             ]
           },
           "GetInlinePolicyForPermissionSet": {
@@ -175,6 +241,13 @@
                 "IntervalSeconds": 2,
                 "MaxAttempts": 2
               }
+            ],
+            "Catch": [
+              {
+                "ErrorEquals": ["States.ALL"],
+                "Next": "Catchall for error handling",
+                "ResultPath": "$.solutionError"
+              }
             ]
           },
           "ListTagsForResource": {
@@ -192,6 +265,13 @@
                 "BackoffRate": 1.5,
                 "IntervalSeconds": 2,
                 "MaxAttempts": 2
+              }
+            ],
+            "Catch": [
+              {
+                "ErrorEquals": ["States.ALL"],
+                "Next": "Catchall for error handling",
+                "ResultPath": "$.solutionError"
               }
             ]
           },
@@ -226,6 +306,17 @@
                       "MaxAttempts": 2
                     }
                   ],
+                  "End": true,
+                  "Catch": [
+                    {
+                      "ErrorEquals": ["States.ALL"],
+                      "Next": "Catchall for inner map 2",
+                      "ResultPath": "$.solutionError"
+                    }
+                  ]
+                },
+                "Catchall for inner map 2": {
+                  "Type": "Pass",
                   "End": true
                 }
               }
@@ -269,6 +360,13 @@
                 "IntervalSeconds": 2,
                 "MaxAttempts": 2
               }
+            ],
+            "Catch": [
+              {
+                "ErrorEquals": ["States.ALL"],
+                "Next": "Catchall for error handling",
+                "ResultPath": "$.solutionError"
+              }
             ]
           },
           "ListTagsForResource with NextToken": {
@@ -288,6 +386,13 @@
                 "IntervalSeconds": 2,
                 "MaxAttempts": 2
               }
+            ],
+            "Catch": [
+              {
+                "ErrorEquals": ["States.ALL"],
+                "Next": "Catchall for error handling",
+                "ResultPath": "$.solutionError"
+              }
             ]
           },
           "Publish to PS import handling topic": {
@@ -306,7 +411,14 @@
                 "MaxAttempts": 2
               }
             ],
-            "ResultPath": null
+            "ResultPath": null,
+            "Catch": [
+              {
+                "ErrorEquals": ["States.ALL"],
+                "Next": "Catchall for error handling",
+                "ResultPath": "$.solutionError"
+              }
+            ]
           },
           "Delete Permission Set": {
             "Type": "Task",
@@ -328,6 +440,13 @@
                 "IntervalSeconds": 2,
                 "MaxAttempts": 2
               }
+            ],
+            "Catch": [
+              {
+                "ErrorEquals": ["States.ALL"],
+                "Next": "Catchall for error handling",
+                "ResultPath": "$.solutionError"
+              }
             ]
           },
           "ListAccountsForProvisionedPermissionSet": {
@@ -347,6 +466,13 @@
                 "BackoffRate": 1.5,
                 "IntervalSeconds": 2,
                 "MaxAttempts": 2
+              }
+            ],
+            "Catch": [
+              {
+                "ErrorEquals": ["States.ALL"],
+                "Next": "Catchall for error handling",
+                "ResultPath": "$.solutionError"
               }
             ]
           },
@@ -374,6 +500,17 @@
                       "pageSize.$": "$.pageSize"
                     }
                   },
+                  "End": true,
+                  "Catch": [
+                    {
+                      "ErrorEquals": ["States.ALL"],
+                      "Next": "Catchall for inner map 3",
+                      "ResultPath": "$.solutionError"
+                    }
+                  ]
+                },
+                "Catchall for inner map 3": {
+                  "Type": "Pass",
                   "End": true
                 }
               }
@@ -393,7 +530,14 @@
               "waitSeconds.$": "$.waitSeconds",
               "pageSize.$": "$.pageSize"
             },
-            "ResultPath": null
+            "ResultPath": null,
+            "Catch": [
+              {
+                "ErrorEquals": ["States.ALL"],
+                "Next": "Catchall for error handling",
+                "ResultPath": "$.solutionError"
+              }
+            ]
           },
           "Check for NextToken in listAccountsForProvisionedPermissionSet call": {
             "Type": "Choice",
@@ -429,6 +573,13 @@
                 "BackoffRate": 1.5,
                 "IntervalSeconds": 2,
                 "MaxAttempts": 2
+              }
+            ],
+            "Catch": [
+              {
+                "ErrorEquals": ["States.ALL"],
+                "Next": "Catchall for error handling",
+                "ResultPath": "$.solutionError"
               }
             ]
           },
@@ -488,11 +639,21 @@
           "IntervalSeconds": 2,
           "MaxAttempts": 2
         }
+      ],
+      "Catch": [
+        {
+          "ErrorEquals": ["States.ALL"],
+          "Next": "Catchall",
+          "ResultPath": "$.solutionError"
+        }
       ]
     },
     "Pass": {
       "Type": "Pass",
-      "End": true
+      "Next": "Success"
+    },
+    "Success": {
+      "Type": "Succeed"
     }
   }
 }

--- a/lib/state-machines/upgrade-to-v303-asl.json
+++ b/lib/state-machines/upgrade-to-v303-asl.json
@@ -22,7 +22,29 @@
       },
       "Resource": "arn:aws:states:::aws-sdk:s3:listObjectsV2",
       "Next": "Only proceed if there is links data",
-      "ResultPath": "$.listObjectsResult"
+      "ResultPath": "$.listObjectsResult",
+      "Retry": [
+        {
+          "ErrorEquals": ["States.TaskFailed"],
+          "BackoffRate": 1.5,
+          "IntervalSeconds": 1,
+          "MaxAttempts": 2
+        }
+      ],
+      "Catch": [
+        {
+          "ErrorEquals": ["States.ALL"],
+          "Next": "Catchall",
+          "ResultPath": "$.solutionError"
+        }
+      ]
+    },
+    "Catchall": {
+      "Type": "Pass",
+      "Next": "Fail"
+    },
+    "Fail": {
+      "Type": "Fail"
     },
     "Only proceed if there is links data": {
       "Type": "Choice",
@@ -96,7 +118,15 @@
               }
             },
             "ResultPath": null,
-            "Next": "DynamoDB PutItem"
+            "Next": "DynamoDB PutItem",
+            "Retry": [
+              {
+                "ErrorEquals": ["States.TaskFailed"],
+                "BackoffRate": 1.5,
+                "IntervalSeconds": 1,
+                "MaxAttempts": 2
+              }
+            ]
           },
           "DynamoDB PutItem": {
             "Type": "Task",
@@ -125,7 +155,15 @@
               }
             },
             "ResultPath": null,
-            "Next": "DeleteObject"
+            "Next": "DeleteObject",
+            "Retry": [
+              {
+                "ErrorEquals": [],
+                "BackoffRate": 1.5,
+                "IntervalSeconds": 1,
+                "MaxAttempts": 2
+              }
+            ]
           },
           "DeleteObject": {
             "Type": "Task",
@@ -135,7 +173,15 @@
             },
             "Resource": "arn:aws:states:::aws-sdk:s3:deleteObject",
             "ResultPath": null,
-            "Next": "PutObject"
+            "Next": "PutObject",
+            "Retry": [
+              {
+                "ErrorEquals": [],
+                "BackoffRate": 1.5,
+                "IntervalSeconds": 1,
+                "MaxAttempts": 2
+              }
+            ]
           },
           "PutObject": {
             "Type": "Task",
@@ -145,7 +191,15 @@
               "Bucket.$": "$.artefactsBucketName",
               "Key.$": "States.Format('links_data/{}',$.awsEntityId)"
             },
-            "Resource": "arn:aws:states:::aws-sdk:s3:putObject"
+            "Resource": "arn:aws:states:::aws-sdk:s3:putObject",
+            "Retry": [
+              {
+                "ErrorEquals": [],
+                "BackoffRate": 1.5,
+                "IntervalSeconds": 1,
+                "MaxAttempts": 2
+              }
+            ]
           },
           "Ignore new format links": {
             "Type": "Pass",
@@ -161,7 +215,14 @@
         "processLinksFunctionName.$": "$.processLinksFunctionName"
       },
       "Next": "Check for NextContinuationToken",
-      "ResultPath": null
+      "ResultPath": null,
+      "Catch": [
+        {
+          "ErrorEquals": ["States.ALL"],
+          "Next": "Catchall",
+          "ResultPath": "$.solutionError"
+        }
+      ]
     },
     "Check for NextContinuationToken": {
       "Type": "Choice",
@@ -184,11 +245,29 @@
       },
       "Resource": "arn:aws:states:::aws-sdk:s3:listObjectsV2",
       "Next": "Process link data",
-      "ResultPath": "$.listObjectsResult"
+      "ResultPath": "$.listObjectsResult",
+      "Retry": [
+        {
+          "ErrorEquals": ["States.TaskFailed"],
+          "BackoffRate": 1.5,
+          "IntervalSeconds": 1,
+          "MaxAttempts": 2
+        }
+      ],
+      "Catch": [
+        {
+          "ErrorEquals": ["States.ALL"],
+          "Next": "Catchall",
+          "ResultPath": "$.solutionError"
+        }
+      ]
     },
     "Ignore Op": {
       "Type": "Pass",
-      "End": true
+      "Next": "Success"
+    },
+    "Success": {
+      "Type": "Succeed"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aws-sso-extensions-for-enterprise",
-  "version": "3.1.1",
+  "version": "3.1.2",
   "bin": {
     "aws-sso-extensions-for-enterprise": "bin/aws-sso-extensions-for-enterprise.js"
   },


### PR DESCRIPTION
*Issue #, if available:* Fixes #52

*Description of changes:*

- Update state machine behaviour for current configuration discovery, region switch and version upgrade to fail gracefully where feasible. This would ensure that when there are multiple entities being processed, the state machines would not fail if one entity processing failed. Instead, the error details are written to logs and the execution continues.
- Instances where the state machines for the scenarios described above throw errors are:
   - When there's an exception for triggering the state machine logic i.e. input cannot be retrieved
   - Any failure (of any type) in region switch deploy triggers a failure. This is by design to ensure that when the state machines trigger a write operation, even a single error rolls back the entire configuration.
 - Add troubleshooting document that explains the logging convention , different cloud watch log groups and insights queries set up by the solution


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
