### PR TITLE
Update schema definitions

### DIFF
--- a/README.md
+++ b/README.md
@@ -325,6 +325,8 @@ If you chose to use `S3` interface for managing your permission sets and account
 - For account assignment operations, uploading a file to the S3 prefix path would map to creating an account assignment and deleting a file from the S3 prefix path would map to deleting an account assignment
 - For permission set operations, uploading a new file to the S3 prefix path would map to creating a permission set, uploading a new copy of the file would map to updating the permission set, and deleting the file would map to deleting the permission set
 
+- Ensure your deployment account has a cloudtrail. If not, the solution will not be able to provision permission sets when moving in and out of OUs as these events will not register with the event bus.
+
 ## Security
 
 See [CONTRIBUTING](CONTRIBUTING.md) for more information.

--- a/lib/lambda-functions/package.json
+++ b/lib/lambda-functions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aws-sso-extensions-for-enterprise-layer",
-  "version": "3.1.3",
+  "version": "3.1.4",
   "description": "AWS SSO Permissions Utility Layer",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"

--- a/lib/lambda-layers/nodejs-layer/nodejs/package.json
+++ b/lib/lambda-layers/nodejs-layer/nodejs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aws-sso-extensions-for-enterprise-layer",
-  "version": "3.1.3",
+  "version": "3.1.4",
   "description": "AWS SSO Permissions Utility Layer",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"

--- a/lib/payload-schema-definitions/Link-API.json
+++ b/lib/payload-schema-definitions/Link-API.json
@@ -23,28 +23,28 @@
       "default": {},
       "oneOf": [
         {
-          "pattern": "root%all%[\\w+=,.@-]{1,32}%[-\\p{L}\\p{M}\\p{S}\\p{N}+@.]{1,1024}%GROUP%ssofile"
+          "pattern": "root%all%[\\w+=,.@-]{1,32}%[_\\-\\p{L}\\p{M}\\p{S}\\p{N}+@.]{1,1024}%GROUP%ssofile"
         },
         {
-          "pattern": "root%all%[\\w+=,.@-]{1,32}%[-\\p{L}\\p{M}\\p{S}\\p{N}+@.]{1,128}%USER%ssofile"
+          "pattern": "root%all%[\\w+=,.@-]{1,32}%[_\\-\\p{L}\\p{M}\\p{S}\\p{N}+@.]{1,128}%USER%ssofile"
         },
         {
-          "pattern": "ou_id%ou-[a-z0-9]{4}-[a-z0-9]{8}%[\\w+=,.@-]{1,32}%[-\\p{L}\\p{M}\\p{S}\\p{N}+@.]{1,1024}%GROUP%ssofile"
+          "pattern": "ou_id%ou-[a-z0-9]{4}-[a-z0-9]{8}%[\\w+=,.@-]{1,32}%[_\\-\\p{L}\\p{M}\\p{S}\\p{N}+@.]{1,1024}%GROUP%ssofile"
         },
         {
-          "pattern": "ou_id%ou-[a-z0-9]{4}-[a-z0-9]{8}%[\\w+=,.@-]{1,32}%[-\\p{L}\\p{M}\\p{S}\\p{N}+@.]{1,128}%USER%ssofile"
+          "pattern": "ou_id%ou-[a-z0-9]{4}-[a-z0-9]{8}%[\\w+=,.@-]{1,32}%[_\\-\\p{L}\\p{M}\\p{S}\\p{N}+@.]{1,128}%USER%ssofile"
         },
         {
-          "pattern": "account%\\d{12}%[\\w+=,.@-]{1,32}%[-\\p{L}\\p{M}\\p{S}\\p{N}+@.]{1,1024}%GROUP%ssofile"
+          "pattern": "account%\\d{12}%[\\w+=,.@-]{1,32}%[_\\-\\p{L}\\p{M}\\p{S}\\p{N}+@.]{1,1024}%GROUP%ssofile"
         },
         {
-          "pattern": "account\\d{12}%[\\w+=,.@-]{1,32}%[-\\p{L}\\p{M}\\p{S}\\p{N}+@.]{1,128}%USER%ssofile"
+          "pattern": "account\\d{12}%[\\w+=,.@-]{1,32}%[_\\-\\p{L}\\p{M}\\p{S}\\p{N}+@.]{1,128}%USER%ssofile"
         },
         {
-          "pattern": "account_tag%[\\w+=,.@-]{1,128}\\^[\\w+=,.@-]{1,256}%[\\w+=,.@-]{1,32}%[-\\p{L}\\p{M}\\p{S}\\p{N}+@.]{1,1024}%GROUP%ssofile"
+          "pattern": "account_tag%[\\w+=,.@-]{1,128}\\^[\\w+=,.@-]{1,256}%[\\w+=,.@-]{1,32}%[_\\-\\p{L}\\p{M}\\p{S}\\p{N}+@.]{1,1024}%GROUP%ssofile"
         },
         {
-          "pattern": "account_tag%[\\w+=,.@-]{1,128}\\^[\\w+=,.@-]{1,256}%[\\w+=,.@-]{1,32}%[-\\p{L}\\p{M}\\p{S}\\p{N}+@.]{1,128}%USER%ssofile"
+          "pattern": "account_tag%[\\w+=,.@-]{1,128}\\^[\\w+=,.@-]{1,256}%[\\w+=,.@-]{1,32}%[_\\-\\p{L}\\p{M}\\p{S}\\p{N}+@.]{1,128}%USER%ssofile"
         }
       ]
     }

--- a/lib/payload-schema-definitions/Link-S3.json
+++ b/lib/payload-schema-definitions/Link-S3.json
@@ -15,28 +15,28 @@
       "default": {},
       "oneOf": [
         {
-          "pattern": "root%all%[\\w+=,.@-]{1,32}%[-\\p{L}\\p{M}\\p{S}\\p{N}+@.]{1,1024}%GROUP%ssofile"
+          "pattern": "root%all%[\\w+=,.@-]{1,32}%[_\\-\\p{L}\\p{M}\\p{S}\\p{N}+@.]{1,1024}%GROUP%ssofile"
         },
         {
-          "pattern": "root%all%[\\w+=,.@-]{1,32}%[-\\p{L}\\p{M}\\p{S}\\p{N}+@.]{1,128}%USER%ssofile"
+          "pattern": "root%all%[\\w+=,.@-]{1,32}%[_\\-\\p{L}\\p{M}\\p{S}\\p{N}+@.]{1,128}%USER%ssofile"
         },
         {
-          "pattern": "ou_id%ou-[a-z0-9]{4}-[a-z0-9]{8}%[\\w+=,.@-]{1,32}%[-\\p{L}\\p{M}\\p{S}\\p{N}+@.]{1,1024}%GROUP%ssofile"
+          "pattern": "ou_id%ou-[a-z0-9]{4}-[a-z0-9]{8}%[\\w+=,.@-]{1,32}%[_\\-\\p{L}\\p{M}\\p{S}\\p{N}+@.]{1,1024}%GROUP%ssofile"
         },
         {
-          "pattern": "ou_id%ou-[a-z0-9]{4}-[a-z0-9]{8}%[\\w+=,.@-]{1,32}%[-\\p{L}\\p{M}\\p{S}\\p{N}+@.]{1,128}%USER%ssofile"
+          "pattern": "ou_id%ou-[a-z0-9]{4}-[a-z0-9]{8}%[\\w+=,.@-]{1,32}%[_\\-\\p{L}\\p{M}\\p{S}\\p{N}+@.]{1,128}%USER%ssofile"
         },
         {
-          "pattern": "account%\\d{12}%[\\w+=,.@-]{1,32}%[-\\p{L}\\p{M}\\p{S}\\p{N}+@.]{1,1024}%GROUP%ssofile"
+          "pattern": "account%\\d{12}%[\\w+=,.@-]{1,32}%[_\\-\\p{L}\\p{M}\\p{S}\\p{N}+@.]{1,1024}%GROUP%ssofile"
         },
         {
-          "pattern": "account\\d{12}%[\\w+=,.@-]{1,32}%[-\\p{L}\\p{M}\\p{S}\\p{N}+@.]{1,128}%USER%ssofile"
+          "pattern": "account\\d{12}%[\\w+=,.@-]{1,32}%[_\\-\\p{L}\\p{M}\\p{S}\\p{N}+@.]{1,128}%USER%ssofile"
         },
         {
-          "pattern": "account_tag%[\\w+=,.@-]{1,128}\\^[\\w+=,.@-]{1,256}%[\\w+=,.@-]{1,32}%[-\\p{L}\\p{M}\\p{S}\\p{N}+@.]{1,1024}%GROUP%ssofile"
+          "pattern": "account_tag%[\\w+=,.@-]{1,128}\\^[\\w+=,.@-]{1,256}%[\\w+=,.@-]{1,32}%[_\\-\\p{L}\\p{M}\\p{S}\\p{N}+@.]{1,1024}%GROUP%ssofile"
         },
         {
-          "pattern": "account_tag%[\\w+=,.@-]{1,128}\\^[\\w+=,.@-]{1,256}%[\\w+=,.@-]{1,32}%[-\\p{L}\\p{M}\\p{S}\\p{N}+@.]{1,128}%USER%ssofile"
+          "pattern": "account_tag%[\\w+=,.@-]{1,128}\\^[\\w+=,.@-]{1,256}%[\\w+=,.@-]{1,32}%[_\\-\\p{L}\\p{M}\\p{S}\\p{N}+@.]{1,128}%USER%ssofile"
         }
       ]
     }

--- a/lib/payload-schema-definitions/PermissionSet-createUpdateAPI.json
+++ b/lib/payload-schema-definitions/PermissionSet-createUpdateAPI.json
@@ -123,27 +123,96 @@
           }
         },
         "inlinePolicyDocument": {
-          "$id": "#/properties/permissionSetData/properties/inlinePolicyDocument",
+          "$id": "#/properties/inlinePolicyDocument",
           "type": "object",
           "title": "The inlinePolicyDocument $schema",
           "description": "Inline Policy Document",
           "default": {},
-
+          "required": ["Version", "Statement"],
           "properties": {
             "Version": {
-              "$id": "#/properties/permissionSetData/properties/inlinePolicyDocument/properties/Version",
+              "$id": "#/properties/inlinePolicyDocument/properties/Version",
               "type": "string",
               "title": "The Version $schema",
               "description": "An explanation about the purpose of this instance.",
               "default": ""
             },
             "Statement": {
-              "$id": "#/properties/permissionSetData/properties/inlinePolicyDocument/properties/Statement",
+              "$id": "#/properties/inlinePolicyDocument/properties/Statement",
               "type": "array",
               "title": "The Statement $schema",
               "description": "An explanation about the purpose of this instance.",
-              "default": []
-            }
+              "default": [],
+              "items": {
+                "$id": "#/properties/inlinePolicyDocument/properties/Statement/items",
+                "anyOf": [
+                  {
+                    "$id": "#/properties/inlinePolicyDocument/properties/Statement/items/anyOf/0",
+                    "type": "object",
+                    "title": "Statement object",
+                    "description": "Statement object",
+                    "default": {},
+                    "required": ["Action", "Resource", "Effect"],
+                    "properties": {
+                      "Action": {
+                        "$id": "#/properties/inlinePolicyDocument/properties/Statement/items/anyOf/0/properties/Action",
+                        "type": "array",
+                        "title": "The Action $schema",
+                        "description": "The permitted actions",
+                        "default": [],
+                        "items": {
+                          "$id": "#/properties/inlinePolicyDocument/properties/Statement/items/anyOf/0/properties/Action/items",
+                          "anyOf": [
+                            {
+                              "$id": "#/properties/inlinePolicyDocument/properties/Statement/items/anyOf/0/properties/Action/items/anyOf/0",
+                              "type": "string",
+                              "title": "Permitted actions",
+                              "description": "The permitted actions",
+                              "default": ""
+                            }
+                          ]
+                        },
+                      },
+                      "Resource": {
+                        "$id": "#/properties/inlinePolicyDocument/properties/Statement/items/anyOf/0/properties/Resource",
+                        "type": ["array", "string"],
+                        "title": "The Resource $schema",
+                        "description": "The resource that has the permission",
+                        "default": [],
+                        "items": {
+                          "$id": "#/properties/inlinePolicyDocument/properties/Statement/items/anyOf/0/properties/Resource/items",
+                          "anyOf": [
+                            {
+                              "$id": "#/properties/inlinePolicyDocument/properties/Statement/items/anyOf/0/properties/Resource/items/anyOf/0",
+                              "type": "string",
+                              "title": "Permitted resources",
+                              "description": "The permitted resources",
+                              "default": "",
+                            }
+                          ]
+                        },
+                      },
+                      "Effect": {
+                        "$id": "#/properties/inlinePolicyDocument/properties/Statement/items/anyOf/0/properties/Effect",
+                        "type": "string",
+                        "title": "The Effect $schema",
+                        "description": "Permission type",
+                        "enum": ["Allow", "Deny"],
+                        "default": "Allow"
+                      },
+                      "Sid": {
+                        "$id": "#/properties/inlinePolicyDocument/properties/Statement/items/anyOf/0/properties/Sid",
+                        "type": "string",
+                        "title": "The Sid $schema",
+                        "description": "Statement id - optional identifier for the statement",
+                        "default": ""
+                      },
+                    },
+                    "additionalProperties": false
+                  }
+                ]
+              }
+            },
           },
           "additionalProperties": false
         }

--- a/lib/payload-schema-definitions/PermissionSet-createUpdateAPI.json
+++ b/lib/payload-schema-definitions/PermissionSet-createUpdateAPI.json
@@ -171,7 +171,7 @@
                               "default": ""
                             }
                           ]
-                        },
+                        }
                       },
                       "Resource": {
                         "$id": "#/properties/permissionSetData/properties/inlinePolicyDocument/properties/Statement/items/anyOf/0/properties/Resource",
@@ -187,10 +187,10 @@
                               "type": "string",
                               "title": "Permitted resources",
                               "description": "The permitted resources",
-                              "default": "",
+                              "default": ""
                             }
                           ]
-                        },
+                        }
                       },
                       "Effect": {
                         "$id": "#/properties/permissionSetData/properties/inlinePolicyDocument/properties/Statement/items/anyOf/0/properties/Effect",
@@ -206,13 +206,13 @@
                         "title": "The Sid $schema",
                         "description": "Statement id - optional identifier for the statement",
                         "default": ""
-                      },
+                      }
                     },
                     "additionalProperties": false
                   }
                 ]
               }
-            },
+            }
           },
           "additionalProperties": false
         }

--- a/lib/payload-schema-definitions/PermissionSet-createUpdateAPI.json
+++ b/lib/payload-schema-definitions/PermissionSet-createUpdateAPI.json
@@ -123,7 +123,7 @@
           }
         },
         "inlinePolicyDocument": {
-          "$id": "#/properties/inlinePolicyDocument",
+          "$id": "#/properties/permissionSetData/properties/inlinePolicyDocument",
           "type": "object",
           "title": "The inlinePolicyDocument $schema",
           "description": "Inline Policy Document",
@@ -131,23 +131,23 @@
           "required": ["Version", "Statement"],
           "properties": {
             "Version": {
-              "$id": "#/properties/inlinePolicyDocument/properties/Version",
+              "$id": "#/properties/permissionSetData/properties/inlinePolicyDocument/properties/Version",
               "type": "string",
               "title": "The Version $schema",
               "description": "An explanation about the purpose of this instance.",
               "default": ""
             },
             "Statement": {
-              "$id": "#/properties/inlinePolicyDocument/properties/Statement",
+              "$id": "#/properties/permissionSetData/properties/inlinePolicyDocument/properties/Statement",
               "type": "array",
               "title": "The Statement $schema",
               "description": "An explanation about the purpose of this instance.",
               "default": [],
               "items": {
-                "$id": "#/properties/inlinePolicyDocument/properties/Statement/items",
+                "$id": "#/properties/permissionSetData/properties/inlinePolicyDocument/properties/Statement/items",
                 "anyOf": [
                   {
-                    "$id": "#/properties/inlinePolicyDocument/properties/Statement/items/anyOf/0",
+                    "$id": "#/properties/permissionSetData/properties/inlinePolicyDocument/properties/Statement/items/anyOf/0",
                     "type": "object",
                     "title": "Statement object",
                     "description": "Statement object",
@@ -155,16 +155,16 @@
                     "required": ["Action", "Resource", "Effect"],
                     "properties": {
                       "Action": {
-                        "$id": "#/properties/inlinePolicyDocument/properties/Statement/items/anyOf/0/properties/Action",
+                        "$id": "#/properties/permissionSetData/properties/inlinePolicyDocument/properties/Statement/items/anyOf/0/properties/Action",
                         "type": "array",
                         "title": "The Action $schema",
                         "description": "The permitted actions",
                         "default": [],
                         "items": {
-                          "$id": "#/properties/inlinePolicyDocument/properties/Statement/items/anyOf/0/properties/Action/items",
+                          "$id": "#/properties/permissionSetData/properties/inlinePolicyDocument/properties/Statement/items/anyOf/0/properties/Action/items",
                           "anyOf": [
                             {
-                              "$id": "#/properties/inlinePolicyDocument/properties/Statement/items/anyOf/0/properties/Action/items/anyOf/0",
+                              "$id": "#/properties/permissionSetData/properties/inlinePolicyDocument/properties/Statement/items/anyOf/0/properties/Action/items/anyOf/0",
                               "type": "string",
                               "title": "Permitted actions",
                               "description": "The permitted actions",
@@ -174,16 +174,16 @@
                         },
                       },
                       "Resource": {
-                        "$id": "#/properties/inlinePolicyDocument/properties/Statement/items/anyOf/0/properties/Resource",
+                        "$id": "#/properties/permissionSetData/properties/inlinePolicyDocument/properties/Statement/items/anyOf/0/properties/Resource",
                         "type": ["array", "string"],
                         "title": "The Resource $schema",
                         "description": "The resource that has the permission",
                         "default": [],
                         "items": {
-                          "$id": "#/properties/inlinePolicyDocument/properties/Statement/items/anyOf/0/properties/Resource/items",
+                          "$id": "#/properties/permissionSetData/properties/inlinePolicyDocument/properties/Statement/items/anyOf/0/properties/Resource/items",
                           "anyOf": [
                             {
-                              "$id": "#/properties/inlinePolicyDocument/properties/Statement/items/anyOf/0/properties/Resource/items/anyOf/0",
+                              "$id": "#/properties/permissionSetData/properties/inlinePolicyDocument/properties/Statement/items/anyOf/0/properties/Resource/items/anyOf/0",
                               "type": "string",
                               "title": "Permitted resources",
                               "description": "The permitted resources",
@@ -193,7 +193,7 @@
                         },
                       },
                       "Effect": {
-                        "$id": "#/properties/inlinePolicyDocument/properties/Statement/items/anyOf/0/properties/Effect",
+                        "$id": "#/properties/permissionSetData/properties/inlinePolicyDocument/properties/Statement/items/anyOf/0/properties/Effect",
                         "type": "string",
                         "title": "The Effect $schema",
                         "description": "Permission type",
@@ -201,7 +201,7 @@
                         "default": "Allow"
                       },
                       "Sid": {
-                        "$id": "#/properties/inlinePolicyDocument/properties/Statement/items/anyOf/0/properties/Sid",
+                        "$id": "#/properties/permissionSetData/properties/inlinePolicyDocument/properties/Statement/items/anyOf/0/properties/Sid",
                         "type": "string",
                         "title": "The Sid $schema",
                         "description": "Statement id - optional identifier for the statement",

--- a/lib/payload-schema-definitions/PermissionSet-createUpdateS3.json
+++ b/lib/payload-schema-definitions/PermissionSet-createUpdateS3.json
@@ -155,7 +155,7 @@
                           "default": ""
                         }
                       ]
-                    },
+                    }
                   },
                   "Resource": {
                     "$id": "#/properties/inlinePolicyDocument/properties/Statement/items/anyOf/0/properties/Resource",
@@ -171,10 +171,10 @@
                           "type": "string",
                           "title": "Permitted resources",
                           "description": "The permitted resources",
-                          "default": "",
+                          "default": ""
                         }
                       ]
-                    },
+                    }
                   },
                   "Effect": {
                     "$id": "#/properties/inlinePolicyDocument/properties/Statement/items/anyOf/0/properties/Effect",
@@ -190,13 +190,13 @@
                     "title": "The Sid $schema",
                     "description": "Statement id - optional identifier for the statement",
                     "default": ""
-                  },
+                  }
                 },
                 "additionalProperties": false
               }
             ]
           }
-        },
+        }
       },
       "additionalProperties": false
     }

--- a/lib/payload-schema-definitions/PermissionSet-createUpdateS3.json
+++ b/lib/payload-schema-definitions/PermissionSet-createUpdateS3.json
@@ -112,7 +112,7 @@
       "title": "The inlinePolicyDocument $schema",
       "description": "Inline Policy Document",
       "default": {},
-
+      "required": ["Version", "Statement"],
       "properties": {
         "Version": {
           "$id": "#/properties/inlinePolicyDocument/properties/Version",
@@ -126,8 +126,77 @@
           "type": "array",
           "title": "The Statement $schema",
           "description": "An explanation about the purpose of this instance.",
-          "default": []
-        }
+          "default": [],
+          "items": {
+            "$id": "#/properties/inlinePolicyDocument/properties/Statement/items",
+            "anyOf": [
+              {
+                "$id": "#/properties/inlinePolicyDocument/properties/Statement/items/anyOf/0",
+                "type": "object",
+                "title": "Statement object",
+                "description": "Statement object",
+                "default": {},
+                "required": ["Action", "Resource", "Effect"],
+                "properties": {
+                  "Action": {
+                    "$id": "#/properties/inlinePolicyDocument/properties/Statement/items/anyOf/0/properties/Action",
+                    "type": "array",
+                    "title": "The Action $schema",
+                    "description": "The permitted actions",
+                    "default": [],
+                    "items": {
+                      "$id": "#/properties/inlinePolicyDocument/properties/Statement/items/anyOf/0/properties/Action/items",
+                      "anyOf": [
+                        {
+                          "$id": "#/properties/inlinePolicyDocument/properties/Statement/items/anyOf/0/properties/Action/items/anyOf/0",
+                          "type": "string",
+                          "title": "Permitted actions",
+                          "description": "The permitted actions",
+                          "default": ""
+                        }
+                      ]
+                    },
+                  },
+                  "Resource": {
+                    "$id": "#/properties/inlinePolicyDocument/properties/Statement/items/anyOf/0/properties/Resource",
+                    "type": ["array", "string"],
+                    "title": "The Resource $schema",
+                    "description": "The resource that has the permission",
+                    "default": [],
+                    "items": {
+                      "$id": "#/properties/inlinePolicyDocument/properties/Statement/items/anyOf/0/properties/Resource/items",
+                      "anyOf": [
+                        {
+                          "$id": "#/properties/inlinePolicyDocument/properties/Statement/items/anyOf/0/properties/Resource/items/anyOf/0",
+                          "type": "string",
+                          "title": "Permitted resources",
+                          "description": "The permitted resources",
+                          "default": "",
+                        }
+                      ]
+                    },
+                  },
+                  "Effect": {
+                    "$id": "#/properties/inlinePolicyDocument/properties/Statement/items/anyOf/0/properties/Effect",
+                    "type": "string",
+                    "title": "The Effect $schema",
+                    "description": "Permission type",
+                    "enum": ["Allow", "Deny"],
+                    "default": "Allow"
+                  },
+                  "Sid": {
+                    "$id": "#/properties/inlinePolicyDocument/properties/Statement/items/anyOf/0/properties/Sid",
+                    "type": "string",
+                    "title": "The Sid $schema",
+                    "description": "Statement id - optional identifier for the statement",
+                    "default": ""
+                  },
+                },
+                "additionalProperties": false
+              }
+            ]
+          }
+        },
       },
       "additionalProperties": false
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aws-sso-extensions-for-enterprise",
-  "version": "3.1.3",
+  "version": "3.1.4",
   "bin": {
     "aws-sso-extensions-for-enterprise": "bin/aws-sso-extensions-for-enterprise.js"
   },


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
**Read me update:**
- Added a note to state that an account must have a CloudTrail for MoveAccount events to be detected by event bus.

**Schema updates:**
- Update link data pattern to support underscores
- Extend the inlinePolicyDocument schema for permission set create. Added required fields and schemas for Action, Resource and Effect

tested new schema using
https://www.jsonschemavalidator.net/

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
