### PR TITLE
Adding description to schema and making tags and relay state as option

### DIFF
--- a/lib/payload-schema-definitions/PermissionSet-createUpdateAPI.json
+++ b/lib/payload-schema-definitions/PermissionSet-createUpdateAPI.json
@@ -24,8 +24,6 @@
       "required": [
         "permissionSetName",
         "sessionDurationInMinutes",
-        "relayState",
-        "tags",
         "managedPoliciesArnList",
         "inlinePolicyDocument"
       ],
@@ -34,11 +32,21 @@
           "$id": "#/properties/permissionSetData/properties/permissionSetName",
           "type": "string",
           "title": "Permission Set Name",
-          "description": "Permission Set Nam",
+          "description": "Permission Set Name",
           "default": "",
           "minLength": 1,
           "maxLength": 32,
           "pattern": "[\\w+=,.@-]+"
+        },
+        "description": {
+          "$id": "#/properties/permissionSetData/properties/description",
+          "type": "string",
+          "title": "description",
+          "description": "Permission set description",
+          "default": "",
+          "minLength": 0,
+          "maxLength": 700,
+          "pattern": "[\\u0009\\u000A\\u000D\\u0020-\\u007E\\u00A1-\\u00FF]*"
         },
         "sessionDurationInMinutes": {
           "$id": "#/properties/permissionSetData/properties/sessionDurationInMinutes",
@@ -94,7 +102,7 @@
                     "default": "",
                     "minLength": 0,
                     "maxLength": 256,
-                    "pattern": "^[A-Za-z0-9_:/=\\+\\-@]*$"
+                    "pattern": "^([\\p{L}\\p{Z}\\p{N}_.:/=+\\-@]*)$"
                   }
                 },
                 "additionalProperties": false

--- a/lib/payload-schema-definitions/PermissionSet-createUpdateS3.json
+++ b/lib/payload-schema-definitions/PermissionSet-createUpdateS3.json
@@ -8,8 +8,6 @@
   "required": [
     "permissionSetName",
     "sessionDurationInMinutes",
-    "relayState",
-    "tags",
     "managedPoliciesArnList",
     "inlinePolicyDocument"
   ],
@@ -18,11 +16,21 @@
       "$id": "#/properties/permissionSetName",
       "type": "string",
       "title": "Permission Set Name",
-      "description": "Permission Set Nam",
+      "description": "Permission Set Name",
       "default": "",
       "minLength": 1,
       "maxLength": 32,
       "pattern": "[\\w+=,.@-]+"
+    },
+    "description": {
+      "$id": "#/properties/description",
+      "type": "string",
+      "title": "description",
+      "description": "Permission set description",
+      "default": "",
+      "minLength": 0,
+      "maxLength": 700,
+      "pattern": "[\\u0009\\u000A\\u000D\\u0020-\\u007E\\u00A1-\\u00FF]*"
     },
     "sessionDurationInMinutes": {
       "$id": "#/properties/sessionDurationInMinutes",
@@ -44,7 +52,7 @@
       "pattern": "[A-Za-z0-9_:/=\\+\\-@#]+"
     },
     "tags": {
-      "$id": "#/properties/tags",
+      "$id": "#/properties/tags", 
       "type": "array",
       "title": "tags",
       "description": "tags",
@@ -78,7 +86,7 @@
                 "default": "",
                 "minLength": 0,
                 "maxLength": 256,
-                "pattern": "^[A-Za-z0-9_:/=\\+\\-@]*$"
+                "pattern": "^([\\p{L}\\p{Z}\\p{N}_.:/=+\\-@]*)$"
               }
             },
             "additionalProperties": false


### PR DESCRIPTION
- Adding description to schema
- Removing tags and relay state from required as they are optional parameters
- Change pattern for tag value to support spaces (new pattern copied from the AWS docs) 

schema validated with
https://www.jsonschemavalidator.net/

Changes have been manually tested