### PR TITLE
Fixed Typo for account-user-ssoprofile Json Schema

### DIFF
--- a/lib/payload-schema-definitions/Link-S3.json
+++ b/lib/payload-schema-definitions/Link-S3.json
@@ -28,7 +28,7 @@
           "pattern": "account%\\d{12}%[\\w+=,.@-]{1,32}%[_\\-\\p{L}\\p{M}\\p{S}\\p{N}+@.]{1,1024}%GROUP%ssofile"
         },
         {
-          "pattern": "account\\d{12}%[\\w+=,.@-]{1,32}%[_\\-\\p{L}\\p{M}\\p{S}\\p{N}+@.]{1,128}%USER%ssofile"
+          "pattern": "account%\\d{12}%[\\w+=,.@-]{1,32}%[_\\-\\p{L}\\p{M}\\p{S}\\p{N}+@.]{1,128}%USER%ssofile"
         },
         {
           "pattern": "account_tag%[\\w+=,.@-]{1,128}\\^[\\w+=,.@-]{1,256}%[\\w+=,.@-]{1,32}%[_\\-\\p{L}\\p{M}\\p{S}\\p{N}+@.]{1,1024}%GROUP%ssofile"


### PR DESCRIPTION
Added missing delimiter `%` for ```account\\d{12}%[\\w+=,.@-]{1,32}%[_\\-\\p{L}\\p{M}\\p{S}\\p{N}+@.]{1,128}%USER%ssofile```

*Issue #, if available:*

- Currently the Json Validation fails for User Permission Set and Group assignment due to invalid Json schema

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
